### PR TITLE
info.plist: remove the public.txt and public.plain-txt contentTypes

### DIFF
--- a/Sources/VLC for iOS-Info.plist
+++ b/Sources/VLC for iOS-Info.plist
@@ -82,7 +82,6 @@
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>public.plain-text</string>
 				<string>org.videolan.srt</string>
 				<string>org.videolan.sub</string>
 				<string>org.videolan.cdg</string>
@@ -95,7 +94,6 @@
 				<string>org.videolan.psb</string>
 				<string>org.videolan.rt</string>
 				<string>org.videolan.smi</string>
-				<string>public.txt</string>
 				<string>org.videolan.smil</string>
 				<string>com.real.smil</string>
 			</array>

--- a/VLC-iOS-Debug-Info.plist
+++ b/VLC-iOS-Debug-Info.plist
@@ -82,7 +82,6 @@
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>public.plain-text</string>
 				<string>org.videolan.srt</string>
 				<string>org.videolan.sub</string>
 				<string>org.videolan.cdg</string>
@@ -95,7 +94,6 @@
 				<string>org.videolan.psb</string>
 				<string>org.videolan.rt</string>
 				<string>org.videolan.smi</string>
-				<string>public.txt</string>
 				<string>org.videolan.smil</string>
 				<string>com.real.smil</string>
 			</array>

--- a/VLC-iOS-no-watch-Debug-Info.plist
+++ b/VLC-iOS-no-watch-Debug-Info.plist
@@ -82,7 +82,6 @@
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>public.plain-text</string>
 				<string>org.videolan.srt</string>
 				<string>org.videolan.sub</string>
 				<string>org.videolan.cdg</string>
@@ -95,7 +94,6 @@
 				<string>org.videolan.psb</string>
 				<string>org.videolan.rt</string>
 				<string>org.videolan.smi</string>
-				<string>public.txt</string>
 				<string>org.videolan.smil</string>
 				<string>com.real.smil</string>
 			</array>


### PR DESCRIPTION
We had complaints by a lot of users that VLC gets chosen for .txt files.
Even though we support this format (because we obviously support all the formats 😜) we shouldn't list them because in the supported content types. so this PR

- [x] removes .txt from the publicly supported file types

