### PR TITLE
VLCKeychainCoordinator: if the passcode is empty we won't show the pa…

### DIFF
--- a/Sources/KeychainCoordinator.swift
+++ b/Sources/KeychainCoordinator.swift
@@ -82,7 +82,9 @@ class KeychainCoordinator:NSObject, PAPasscodeViewControllerDelegate {
     @objc func validatePasscode(completion:@escaping ()->()) {
         passcodeLockController.passcode = passcodeFromKeychain()
         self.completion = completion
-        guard let rootViewController = UIApplication.shared.delegate?.window??.rootViewController else {
+        guard let rootViewController = UIApplication.shared.delegate?.window??.rootViewController, passcodeLockController.passcode != "" else {
+            self.completion?()
+            self.completion = nil
             return
         }
         if rootViewController.presentedViewController != nil {


### PR DESCRIPTION
…sscode screen

We had some users that said they were prompted by the passcode screen even though they never set a passcode. I just ran into that issue. This will fix the presentation but still not the underlying bug which is that passcode lock is all of a sudden enabled in the settings but we don't have a passcode. 

I am really not sure what is causing the wrong settings value from the userdefaults tbh 