### PR TITLE
[Playback] iOS control center media controls

### DIFF
--- a/SharedSources/VLCRemoteControlService.h
+++ b/SharedSources/VLCRemoteControlService.h
@@ -24,6 +24,7 @@
 - (void)remoteControlService:(VLCRemoteControlService *)rcs jumpBackwardInSeconds:(NSTimeInterval)seconds;
 - (NSInteger)remoteControlServiceNumberOfMediaItemsinList:(VLCRemoteControlService *)rcs;
 - (void)remoteControlService:(VLCRemoteControlService *)rcs setPlaybackRate:(CGFloat)playbackRate;
+- (void)remoteControlService:(VLCRemoteControlService *)rcs setCurrentPlaybackTime:(NSTimeInterval)playbackTime;
 
 @end
 

--- a/SharedSources/VLCRemoteControlService.m
+++ b/SharedSources/VLCRemoteControlService.m
@@ -27,6 +27,7 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
              cc.skipForwardCommand,
              cc.skipBackwardCommand,
              cc.changePlaybackRateCommand,
+             cc.changePlaybackPositionCommand,
              ];
 }
 
@@ -56,7 +57,7 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
     commandCenter.changeShuffleModeCommand.enabled = NO;
     commandCenter.seekForwardCommand.enabled = NO;
     commandCenter.seekBackwardCommand.enabled = NO;
-    commandCenter.changePlaybackPositionCommand.enabled = NO;
+    commandCenter.changePlaybackPositionCommand.enabled = YES;
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSNumber *forwardSkip = [defaults valueForKey:kVLCSettingPlaybackForwardSkipLength];
@@ -123,6 +124,11 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
     if (event.command == cc.changePlaybackRateCommand) {
         MPChangePlaybackRateCommandEvent *rateEvent = (MPChangePlaybackRateCommandEvent *)event;
         [_remoteControlServiceDelegate remoteControlService:self setPlaybackRate:rateEvent.playbackRate];
+        return MPRemoteCommandHandlerStatusSuccess;
+    }
+    if (event.command == cc.changePlaybackPositionCommand) {
+        MPChangePlaybackPositionCommandEvent *positionEvent = (MPChangePlaybackPositionCommandEvent *)event;
+        [_remoteControlServiceDelegate remoteControlService:self setCurrentPlaybackTime:positionEvent.positionTime];
         return MPRemoteCommandHandlerStatusSuccess;
     }
     NSAssert(NO, @"remote control event not handled");

--- a/SharedSources/VLCRemoteControlService.m
+++ b/SharedSources/VLCRemoteControlService.m
@@ -129,10 +129,12 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
         [_remoteControlServiceDelegate remoteControlService:self setPlaybackRate:rateEvent.playbackRate];
         return MPRemoteCommandHandlerStatusSuccess;
     }
-    if (event.command == cc.changePlaybackPositionCommand) {
-        MPChangePlaybackPositionCommandEvent *positionEvent = (MPChangePlaybackPositionCommandEvent *)event;
-        [_remoteControlServiceDelegate remoteControlService:self setCurrentPlaybackTime:positionEvent.positionTime];
-        return MPRemoteCommandHandlerStatusSuccess;
+    if (@available(iOS 9.1, *)) {
+        if (event.command == cc.changePlaybackPositionCommand) {
+            MPChangePlaybackPositionCommandEvent *positionEvent = (MPChangePlaybackPositionCommandEvent *)event;
+            [_remoteControlServiceDelegate remoteControlService:self setCurrentPlaybackTime:positionEvent.positionTime];
+            return MPRemoteCommandHandlerStatusSuccess;
+        }
     }
     NSAssert(NO, @"remote control event not handled");
     APLog(@"%s Wasn't able to handle remote control event: %@",__PRETTY_FUNCTION__,event);

--- a/SharedSources/VLCRemoteControlService.m
+++ b/SharedSources/VLCRemoteControlService.m
@@ -32,7 +32,7 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
     if (@available(iOS 9.1, *)) {
         [commands addObject:cc.changePlaybackPositionCommand];
     }
-    return commands;
+    return [commands copy];
 }
 
 - (void)subscribeToRemoteCommands

--- a/SharedSources/VLCRemoteControlService.m
+++ b/SharedSources/VLCRemoteControlService.m
@@ -18,17 +18,21 @@
 static inline NSArray * RemoteCommandCenterCommandsToHandle()
 {
     MPRemoteCommandCenter *cc = [MPRemoteCommandCenter sharedCommandCenter];
-    return @[cc.pauseCommand,
-             cc.playCommand,
-             cc.stopCommand,
-             cc.togglePlayPauseCommand,
-             cc.nextTrackCommand,
-             cc.previousTrackCommand,
-             cc.skipForwardCommand,
-             cc.skipBackwardCommand,
-             cc.changePlaybackRateCommand,
-             cc.changePlaybackPositionCommand,
-             ];
+    NSMutableArray *commands = [NSMutableArray arrayWithObjects:
+                                cc.pauseCommand,
+                                cc.playCommand,
+                                cc.stopCommand,
+                                cc.togglePlayPauseCommand,
+                                cc.nextTrackCommand,
+                                cc.previousTrackCommand,
+                                cc.skipForwardCommand,
+                                cc.skipBackwardCommand,
+                                cc.changePlaybackRateCommand,
+                                nil];
+    if (@available(iOS 9.1, *)) {
+        [commands addObject:cc.changePlaybackPositionCommand];
+    }
+    return commands;
 }
 
 - (void)subscribeToRemoteCommands
@@ -57,7 +61,6 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
     commandCenter.changeShuffleModeCommand.enabled = NO;
     commandCenter.seekForwardCommand.enabled = NO;
     commandCenter.seekBackwardCommand.enabled = NO;
-    commandCenter.changePlaybackPositionCommand.enabled = YES;
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSNumber *forwardSkip = [defaults valueForKey:kVLCSettingPlaybackForwardSkipLength];

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1256,6 +1256,13 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
 {
     self.playbackRate = playbackRate;
 }
+
+- (void)remoteControlService:(VLCRemoteControlService *)rcs setCurrentPlaybackTime:(NSTimeInterval)playbackTime
+{
+    float positionDiff = playbackTime - [self.metadata.elapsedPlaybackTime floatValue];
+    [_mediaPlayer jumpForward:positionDiff];
+}
+
 #pragma mark - helpers
 
 - (NSDictionary *)mediaOptionsDictionary

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1106,8 +1106,10 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
         CGFloat lastPosition = .0;
         NSInteger duration = 0;
 
-        if (item.lastPosition)
+        if (item.lastPosition) {
             lastPosition = item.lastPosition.floatValue;
+        }
+        
         duration = item.duration.intValue;
 
         if (lastPosition < .95 && _mediaPlayer.position < lastPosition) {
@@ -1118,7 +1120,7 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
                 continuePlayback = [[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingContinuePlayback] integerValue];
 
             if (continuePlayback == 1) {
-                _mediaPlayer.position = lastPosition;
+                [self jumpForward:(duration * lastPosition) / 1000.];
             } else if (continuePlayback == 0) {
                 VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"CONTINUE_PLAYBACK", nil)
                                                                   message:[NSString stringWithFormat:NSLocalizedString(@"CONTINUE_PLAYBACK_LONG", nil), item.title]
@@ -1127,7 +1129,7 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
                                                         otherButtonTitles:NSLocalizedString(@"BUTTON_CONTINUE", nil), nil];
                 alert.completion = ^(BOOL cancelled, NSInteger buttonIndex) {
                     if (!cancelled) {
-                        _mediaPlayer.position = lastPosition;
+                        [self setPlaybackPosition:lastPosition];
                     }
                 };
                 [alert show];

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -504,7 +504,10 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
 
 - (void)setPlaybackPosition:(float)position
 {
-    _mediaPlayer.position = position;
+#warning Should use `position` to change position. This is a hack!
+    float oldPosition = _mediaPlayer.position;
+    float diff = position - oldPosition;
+    [_mediaPlayer jumpForward:(diff * self.mediaDuration)/1000.];
 }
 
 - (void)setSubtitleDelay:(float)subtitleDeleay

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -504,10 +504,7 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
 
 - (void)setPlaybackPosition:(float)position
 {
-#warning Should use `position` to change position. This is a hack!
-    float oldPosition = _mediaPlayer.position;
-    float diff = position - oldPosition;
-    [_mediaPlayer jumpForward:(diff * self.mediaDuration)/1000.];
+    _mediaPlayer.position = position;
 }
 
 - (void)setSubtitleDelay:(float)subtitleDeleay
@@ -1123,7 +1120,7 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
                 continuePlayback = [[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingContinuePlayback] integerValue];
 
             if (continuePlayback == 1) {
-                [self jumpForward:(duration * lastPosition) / 1000.];
+                [self setPlaybackPosition:lastPosition];
             } else if (continuePlayback == 0) {
                 VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"CONTINUE_PLAYBACK", nil)
                                                                   message:[NSString stringWithFormat:NSLocalizedString(@"CONTINUE_PLAYBACK_LONG", nil), item.title]


### PR DESCRIPTION
It seems like simply setting ` _mediaPlayer.position` does not actually change the position of control center's scrubber; or am I missing something???

My workaround was using the `[VLCMediaPlayer jumpFoward:Int]` function to take care of all the magic that happens behind the scenes for me.