### PR TITLE
VLCPlaybackController: fix openURL crash

### DIFF
--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -295,9 +295,9 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
     [_shuffleStack removeAllObjects];
 
     if (_errorCallback && _mediaPlayer.state == VLCMediaPlayerStateError &&  !_sessionWillRestart)
-        [[UIApplication sharedApplication] openURL:_errorCallback options:@{} completionHandler:nil];
+        [[UIApplication sharedApplication] openURL:_errorCallback];
     else if (_successCallback && !_sessionWillRestart)
-        [[UIApplication sharedApplication] openURL:_successCallback options:@{} completionHandler:nil];
+        [[UIApplication sharedApplication] openURL:_successCallback];
 
     [[self remoteControlService] unsubscribeFromRemoteCommands];
 


### PR DESCRIPTION
openURL with options and completion is iOS 10+ hence we're going back to the old call