### PR TITLE
tvOS: Remove display of playback control on mediaPlayerStateChanged (closes #141)

### DIFF
--- a/Apple-TV/Playback/VLCFullscreenMovieTVViewController.m
+++ b/Apple-TV/Playback/VLCFullscreenMovieTVViewController.m
@@ -827,15 +827,12 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
         if (self.movieView.subviews.count < 2) {
             controller.videoOutputView = self.movieView;
         }
-        [self hidePlaybackControlsIfNeededAfterDelay];
-    } else {
-        [self showPlaybackControlsIfNeededForUserInteraction];
-    }
 
-    if (controller.isPlaying && !self.bufferingLabel.hidden) {
-        [UIView animateWithDuration:.3 animations:^{
-            self.bufferingLabel.hidden = YES;
-        }];
+        if (!self.bufferingLabel.hidden) {
+            [UIView animateWithDuration:.3 animations:^{
+                self.bufferingLabel.hidden = YES;
+            }];
+        }
     }
 }
 


### PR DESCRIPTION
This removes the playback controls show/hide on `mediaPlayerStateChanged` which could lead to non-user-friendly experiences such as [#141](https://code.videolan.org/videolan/vlc-ios/issues/141).