### PR TITLE
VLCOpenNetworkStream: move controller from moretab to LocalNetwork tab

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "SHARING_SUCCESS_CAMERA_ROLL" = "File was successfully saved to the Camera Roll";
 
 "SECTION_HEADER_LIBRARY" = "Media Library";
+"STREAMVC_DETAILTEXT" = "Play streams directly without downloading";
 
 "LOCAL_NETWORK" = "Local Network";
 "CONNECT_TO_SERVER" = "Connect to Server";
@@ -303,7 +304,6 @@
 
 "PROTOCOL_NOT_SELECTED" = "Protocol not selected";
 "Settings" = "Settings";
-
 "FILE_NOT_SUPPORTED_LONG" = "FILE_NOT_SUPPORTED_LONG";
 
 "CANCEL" = "Cancel";

--- a/Sources/LocalNetworkConnectivity/RemoteNetworkDataSource.swift
+++ b/Sources/LocalNetworkConnectivity/RemoteNetworkDataSource.swift
@@ -12,8 +12,14 @@
 import Foundation
 
 enum RemoteNetworkCellType: Int {
-    case cloud = 0, wifi
-    static let count: Int = 2
+    case cloud
+    case streaming
+    case wifi
+    static let count: Int = {
+        var max: Int = 0
+        while let _ = RemoteNetworkCellType(rawValue: max) { max += 1 }
+        return max
+    }()
 }
 
 @objc(VLCRemoteNetworkDataSourceDelegate)
@@ -23,6 +29,8 @@ protocol RemoteNetworkDataSourceDelegate {
 @objc(VLCRemoteNetworkDataSourceAndDelegate)
 public class RemoteNetworkDataSource: NSObject, UITableViewDataSource, UITableViewDelegate {
     let cloudVC = VLCCloudServicesTableViewController(nibName: "VLCCloudServicesTableViewController", bundle: Bundle.main)
+    let streamingVC = VLCOpenNetworkStreamViewController(nibName: "VLCOpenNetworkStreamViewController", bundle: Bundle.main)
+
     @objc weak var delegate: RemoteNetworkDataSourceDelegate?
 
     @objc public let height = RemoteNetworkCellType.count * 55
@@ -45,7 +53,14 @@ public class RemoteNetworkDataSource: NSObject, UITableViewDataSource, UITableVi
                 networkCell.imageView?.image = cloudVC.cellImage
                 return networkCell
             }
-
+        case .streaming:
+            if let networkCell = tableView.dequeueReusableCell(withIdentifier: VLCRemoteNetworkCell.cellIdentifier) {
+                networkCell.textLabel?.text = streamingVC.title
+                networkCell.detailTextLabel?.text = streamingVC.detailText
+                networkCell.imageView?.image = streamingVC.cellImage
+                networkCell.accessibilityIdentifier = "Stream"
+                return networkCell
+            }
         case .wifi:
             if let wifiCell = tableView.dequeueReusableCell(withIdentifier: VLCWiFiUploadTableViewCell.cellIdentifier()) {
                 return wifiCell
@@ -75,6 +90,8 @@ public class RemoteNetworkDataSource: NSObject, UITableViewDataSource, UITableVi
         switch cellType {
         case .cloud:
             return cloudVC
+        case .streaming:
+            return streamingVC
         case .wifi:
             assertionFailure("We shouldn't get in here since we return nil in willSelect")
             return nil

--- a/Sources/VLCOpenNetworkStreamViewController.h
+++ b/Sources/VLCOpenNetworkStreamViewController.h
@@ -22,6 +22,9 @@
 @property (strong, nonatomic) IBOutlet UITableView *historyTableView;
 @property (strong, nonatomic) IBOutlet UILabel *whatToOpenHelpLabel;
 
+@property (nonatomic, readonly, copy) NSString *detailText;
+@property (nonatomic, readonly) UIImage *cellImage;
+
 - (IBAction)openButtonAction:(id)sender;
 
 @end

--- a/Sources/VLCOpenNetworkStreamViewController.m
+++ b/Sources/VLCOpenNetworkStreamViewController.m
@@ -33,8 +33,16 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
     NSDictionary *appDefaults = @{kVLCRecentURLs : @[], kVLCRecentURLTitles : @{}, kVLCPrivateWebStreaming : @(NO)};
-
     [defaults registerDefaults:appDefaults];
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        self.title = NSLocalizedString(@"OPEN_NETWORK", comment: "");
+    }
+    return self;
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
@@ -60,10 +68,10 @@
                                name:NSUbiquitousKeyValueStoreDidChangeExternallyNotification
                              object:[NSUbiquitousKeyValueStore defaultStore]];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(updateForTheme)
-                                                 name:kVLCThemeDidChangeNotification
-                                               object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(updateForTheme)
+                               name:kVLCThemeDidChangeNotification
+                             object:nil];
     /* force store update */
     NSUbiquitousKeyValueStore *ubiquitousKeyValueStore = [NSUbiquitousKeyValueStore defaultStore];
     [ubiquitousKeyValueStore synchronize];
@@ -120,6 +128,16 @@
     [sharedMenuController setMenuItems:@[renameItem]];
     [sharedMenuController update];
     [self updateForTheme];
+}
+
+- (NSString *)detailText
+{
+    return NSLocalizedString(@"STREAMVC_DETAILTEXT", nil);
+}
+
+- (UIImage *)cellImage
+{
+    return [UIImage imageNamed:@"OpenNetStream"];
 }
 
 - (void)updateForTheme

--- a/Sources/VLCTabBarCoordinator.swift
+++ b/Sources/VLCTabBarCoordinator.swift
@@ -85,7 +85,7 @@ class VLCTabbarCooordinator: NSObject, VLCMediaViewControllerDelegate, UITabBarC
             title: NSLocalizedString("LOCAL_NETWORK", comment: ""),
             image: UIImage(named: "Local"),
             selectedImage: UIImage(named: "Local"))
-        serverVC.tabBarItem.accessibilityIdentifier = "Server"
+        serverVC.tabBarItem.accessibilityIdentifier = "LocalNetwork"
 
         //Settings
         let settingsVC = VLCSettingsController()
@@ -105,16 +105,7 @@ class VLCTabbarCooordinator: NSObject, VLCMediaViewControllerDelegate, UITabBarC
             selectedImage:  UIImage(named: "Downloads"))
         downloadVC.tabBarItem.accessibilityIdentifier = "Downloads"
 
-        //Streaming
-        let streamVC = VLCOpenNetworkStreamViewController(nibName: "VLCOpenNetworkStreamViewController", bundle: Bundle.main)
-        streamVC.title = NSLocalizedString("OPEN_NETWORK", comment: "")
-        streamVC.tabBarItem = UITabBarItem(
-            title:  NSLocalizedString("OPEN_NETWORK", comment: ""),
-            image: UIImage(named: "OpenNetStream"),
-            selectedImage: UIImage(named: "OpenNetStream"))
-        streamVC.tabBarItem.accessibilityIdentifier = "Stream"
-
-        let controllers = [audioVC, serverVC, videoVC, settingsVC, downloadVC, streamVC]
+        let controllers = [audioVC, serverVC, videoVC, settingsVC, downloadVC]
         tabBarController.viewControllers = controllers.map { UINavigationController(rootViewController: $0)}
     }
 

--- a/VLC for iOSUITests/Screenshot.swift
+++ b/VLC for iOSUITests/Screenshot.swift
@@ -34,7 +34,7 @@ class Screenshot: XCTestCase {
     
     func testCaptureVideoPlayback() {
         download(name: "http://jell.yfish.us/media/jellyfish-10-mbps-hd-h264.mkv")
-        helper.tap(.Video)
+        helper.tapTabBarItem(.Video)
         app.collectionViews.cells.element(boundBy: 0).tap()
         XCUIDevice.shared.orientation = .landscapeLeft
         
@@ -42,22 +42,22 @@ class Screenshot: XCTestCase {
     }
     
     func testCaptureAudioTab() {
-        helper.tap(.Audio)
+        helper.tapTabBarItem(.Audio)
         snapshot("audio_tab")
     }
     
     func testCaptureNetworkTab() {
-        helper.tap(.Server)
+        helper.tapTabBarItem(.LocalNetwork)
         snapshot("network_tab")
     }
     
     func testCaptureVideoTab() {
-        helper.tap(.Video)
+        helper.tapTabBarItem(.Video)
         snapshot("video_tab")
     }
     
     func download(name fileName: String) {
-        helper.tap(.Downloads)
+        helper.tapTabBarItem(.Downloads)
         
         let downloadTextfield = app.textFields["http://myserver.com/file.mkv"]
         downloadTextfield.clearAndEnter(text: fileName)

--- a/VLC for iOSUITests/TestHelper.swift
+++ b/VLC for iOSUITests/TestHelper.swift
@@ -14,7 +14,7 @@ import Foundation
 import XCTest
 
 enum Tab: String {
-    case Video, Audio, Server, Cloud
+    case Video, Audio, LocalNetwork, Cloud
     case Settings, Downloads, Stream, About
 }
 
@@ -25,7 +25,7 @@ struct TestHelper {
         self.app = app
     }
 
-    func tap(_ type: Tab) {
+    func tapTabBarItem(_ type: Tab) {
         app.tabBars.buttons[type.rawValue].tap()
     }
 }

--- a/VLC for iOSUITests/VLCiOSTestMenu.swift
+++ b/VLC for iOSUITests/VLCiOSTestMenu.swift
@@ -27,42 +27,43 @@ class VLCiOSTestMenu: XCTestCase {
     }
 
     func testNavigationToAudioTab() {
-        helper.tap(.Audio)
+        helper.tapTabBarItem(.Audio)
         XCTAssertNotNil(app.navigationBars[Tab.Audio.rawValue])
     }
 
     func testNavigationToNetworkTab() {
-        helper.tap(.Server)
-        XCTAssertNotNil(app.navigationBars[Tab.Server.rawValue])
+        helper.tapTabBarItem(.LocalNetwork)
+        XCTAssertNotNil(app.navigationBars[Tab.LocalNetwork.rawValue])
     }
 
     func testNavigationToVideoTab() {
-        helper.tap(.Video)
+        helper.tapTabBarItem(.Video)
         XCTAssertNotNil(app.navigationBars[Tab.Video.rawValue])
     }
 
     func testNavigationToSettingsTab() {
-        helper.tap(.Settings)
+        helper.tapTabBarItem(.Settings)
         XCTAssertNotNil(app.navigationBars[Tab.Settings.rawValue])
     }
 
     func testNavigationToCloudServices() {
-        helper.tap(.Cloud)
+        helper.tapTabBarItem(.Cloud)
         XCTAssertNotNil(app.navigationBars[Tab.Cloud.rawValue])
     }
 
     func testNavigationToDownloads() {
-        helper.tap(.Downloads)
+        helper.tapTabBarItem(.Downloads)
         XCTAssertNotNil(app.navigationBars[Tab.Downloads.rawValue])
     }
 
     func testNavigationToNetworkStream() {
-        helper.tap(.Stream)
+        helper.tapTabBarItem(.LocalNetwork)
+        app.cells["Stream"].tap()
         XCTAssertNotNil(app.navigationBars[Tab.Stream.rawValue])
     }
 
     func testNavigationToAbout() {
-        helper.tap(.Settings)
+        helper.tapTabBarItem(.Settings)
         app.cells["About"].tap()
         XCTAssertNotNil(app.navigationBars[Tab.About.rawValue])
     }

--- a/VLC for iOSUITests/VLCiOSTestVideoCodecs.swift
+++ b/VLC for iOSUITests/VLCiOSTestVideoCodecs.swift
@@ -44,7 +44,7 @@ class VLCiOSTestVideoCodecs: XCTestCase {
     }
 
     func stream(named fileName: String) {
-        helper.tap(.Stream)
+        helper.tapTabBarItem(.Stream)
 
         let addressTextField = app.textFields["http://myserver.com/file.mkv"]
         addressTextField.clearAndEnter(text: fileName)

--- a/vlc-ios/Images.xcassets/menu/OpenNetStream.imageset/Contents.json
+++ b/vlc-ios/Images.xcassets/menu/OpenNetStream.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "OpenNetStream.png"
+      "filename" : "OpenNetStream.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "OpenNetStream@2x.png"
+      "filename" : "OpenNetStream@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "OpenNetStream@3x.png"
+      "filename" : "OpenNetStream@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This adjusts the tests as well for streaming. I have to bug louis though about this screen and the detailtext.
![simulator screen shot - iphone 8 plus - 2018-04-19 at 17 20 03](https://user-images.githubusercontent.com/2445653/39001153-f1479662-43f5-11e8-8e23-c47547723292.png)