### PR TITLE
[UI] Fix empty view behavior

### DIFF
--- a/Sources/MediaViewController.swift
+++ b/Sources/MediaViewController.swift
@@ -85,11 +85,11 @@ public class VLCMediaViewController: UICollectionViewController, UISearchResults
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        displayEmptyViewIfNeeded()
         services.mediaDataSource.updateContents(forSelection: nil)
         services.mediaDataSource.addAllFolders()
         services.mediaDataSource.addRemainingFiles()
         collectionView?.reloadData()
+        displayEmptyViewIfNeeded()
     }
     
     func setupSearchController() {


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Empty view now only appears when the library is empty, as one would expect it to
