### PR TITLE
LocalNetworkView: Corrected size and scrolling behavior of the tableview

### DIFF
--- a/Sources/LocalNetworkConnectivity/RemoteNetworkDataSource.swift
+++ b/Sources/LocalNetworkConnectivity/RemoteNetworkDataSource.swift
@@ -35,8 +35,6 @@ public class RemoteNetworkDataSource: NSObject, UITableViewDataSource, UITableVi
 
     @objc weak var delegate: RemoteNetworkDataSourceDelegate?
 
-    @objc public let height = RemoteNetworkCellType.count * 55
-
     // MARK: - DataSource
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return RemoteNetworkCellType.count

--- a/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
@@ -53,6 +53,7 @@
     UIScrollView *_scrollView;
     VLCRemoteNetworkDataSourceAndDelegate *_remoteNetworkDataSourceAndDelegate;
     NSLayoutConstraint* _localNetworkHeight;
+    NSLayoutConstraint* _remoteNetworkHeight;
 }
 
 @end
@@ -115,19 +116,19 @@
     [_scrollView addSubview:_remoteNetworkTableView];
 
     [_remoteNetworkTableView layoutIfNeeded];
-    CGSize contentSize = [_remoteNetworkTableView contentSize];
     _localNetworkHeight = [_localNetworkTableView.heightAnchor constraintEqualToConstant:_localNetworkTableView.contentSize.height];
+    _remoteNetworkHeight = [_remoteNetworkTableView.heightAnchor constraintEqualToConstant:_remoteNetworkTableView.contentSize.height];
 
     [NSLayoutConstraint activateConstraints:@[
                                               [_remoteNetworkTableView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor],
                                               [_remoteNetworkTableView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor],
                                               [_remoteNetworkTableView.topAnchor constraintEqualToAnchor:_scrollView.topAnchor],
-                                              [_remoteNetworkTableView.heightAnchor constraintEqualToConstant:contentSize.height],
                                               [_localNetworkTableView.topAnchor constraintEqualToAnchor:_remoteNetworkTableView.bottomAnchor],
                                               [_localNetworkTableView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor],
                                               [_localNetworkTableView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor],
                                               [_localNetworkTableView.bottomAnchor constraintEqualToAnchor:_scrollView.bottomAnchor],
-                                              _localNetworkHeight
+                                              _localNetworkHeight,
+                                              _remoteNetworkHeight
                                               ]];
     _scrollView.backgroundColor = PresentationTheme.current.colors.background;
 }
@@ -137,6 +138,7 @@
     [super viewDidLoad];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(themeDidChange) name:kVLCThemeDidChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeDidChange) name:UIContentSizeCategoryDidChangeNotification object:nil];
 
     NSArray *browserClasses = @[
                                 [VLCLocalNetworkServiceBrowserManualConnect class],
@@ -177,6 +179,13 @@
     return YES;
 }
 
+- (void)contentSizeDidChange
+{
+    [_localNetworkTableView layoutIfNeeded];
+    _localNetworkHeight.constant = _localNetworkTableView.contentSize.height;
+    [_remoteNetworkTableView layoutIfNeeded];
+    _remoteNetworkHeight.constant = _remoteNetworkTableView.contentSize.height;
+}
 #pragma mark - table view handling
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -191,7 +200,6 @@
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(VLCNetworkListCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (tableView == _remoteNetworkTableView) return;
     UIColor *color = (indexPath.row % 2 == 0)? PresentationTheme.current.colors.cellBackgroundB : PresentationTheme.current.colors.cellBackgroundA;
     cell.backgroundColor = cell.titleLabel.backgroundColor = cell.folderTitleLabel.backgroundColor = cell.subtitleLabel.backgroundColor = color;
     cell.titleLabel.textColor = cell.folderTitleLabel.textColor = cell.subtitleLabel.textColor = cell.thumbnailView.tintColor = PresentationTheme.current.colors.cellTextColor;

--- a/Sources/VLCWiFiUploadTableViewCell.m
+++ b/Sources/VLCWiFiUploadTableViewCell.m
@@ -56,7 +56,6 @@
 
     self.textLabel.text = NSLocalizedString(@"WEBINTF_TITLE", nil);
     self.detailTextLabel.text = NSLocalizedString(@"HTTP_UPLOAD_SERVER_OFF", nil);
-    self.detailTextLabel.translatesAutoresizingMaskIntoConstraints = NO;
     self.detailTextLabel.numberOfLines = 0;
 
     self.serverToggle = [[UISwitch alloc] init];

--- a/Sources/VLCWiFiUploadTableViewCell.m
+++ b/Sources/VLCWiFiUploadTableViewCell.m
@@ -29,8 +29,8 @@
 {
     self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier];
     if (self) {
+        [self setupReachability];
         [self setupCell];
-        [self updateHTTPServerAddress];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(netReachabilityChanged) name:kReachabilityChangedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateTheme) name:kVLCThemeDidChangeNotification object:nil];
     }
@@ -47,11 +47,14 @@
     return @"VLCWiFiUploadTableViewCell";
 }
 
-- (void)setupCell
+- (void)setupReachability
 {
     self.reachability = [Reachability reachabilityForLocalWiFi];
     [self.reachability startNotifier];
+}
 
+- (void)setupCell
+{
     self.selectionStyle =  UITableViewCellSelectionStyleNone;
 
     self.textLabel.text = NSLocalizedString(@"WEBINTF_TITLE", nil);
@@ -65,6 +68,7 @@
     self.imageView.image = [UIImage imageNamed:@"WifiIcon"];
 
     [self updateTheme];
+    [self updateHTTPServerAddress];
 }
 
 - (void)updateTheme
@@ -98,4 +102,9 @@
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    [self setupCell];
+}
 @end


### PR DESCRIPTION
The height of the remotetableView gets now calculated dynamically and both views can now scroll when they get too big for the screen

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
