### PR TITLE
[WIP] UI-Tests: disable animations

### DIFF
--- a/Sources/VLCAppDelegate+UITests.swift
+++ b/Sources/VLCAppDelegate+UITests.swift
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * VLCAppDelegate+UITests.swift
+ *
+ * Copyright © 2018 VLC authors and VideoLAN
+ * Copyright © 2018 Videolabs
+ *
+ * Authors: Kevin Bettin <Kevin # evenly.io>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
+
+import Foundation
+
+extension VLCAppDelegate {
+
+    @objc func setupUITests() {
+        disableAnimations()
+    }
+
+    private func disableAnimations() {
+        guard CommandLine.arguments.contains("-disableAnimations") else {
+            UIView.setAnimationsEnabled(true)
+            return
+        }
+        
+        UIView.setAnimationsEnabled(false)
+    }
+}

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -89,6 +89,15 @@ NSString *const VLCDropboxSessionWasAuthorized = @"VLCDropboxSessionWasAuthorize
     [defaults registerDefaults:appDefaults];
 }
 
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
+{
+#if DEBUG
+    [self setupUITests];
+#endif
+
+    return YES;
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     BITHockeyManager *hockeyManager = [BITHockeyManager sharedHockeyManager];

--- a/VLC-iOS-Bridging-Header.h
+++ b/VLC-iOS-Bridging-Header.h
@@ -5,6 +5,7 @@
 
 #import "UIColor+Presets.h"
 #import "VLCAboutViewController.h"
+#import "VLCAppDelegate.h"
 #import "VLCCloudServicesTableViewController.h"
 #import "VLCConstants.h"
 #import "VLCDownloadViewController.h"

--- a/VLC-iOS-UITests/VLCiOSTestMenu.swift
+++ b/VLC-iOS-UITests/VLCiOSTestMenu.swift
@@ -23,6 +23,7 @@ class VLCiOSTestMenu: XCTestCase {
         XCUIDevice.shared.orientation = .portrait
         setupSnapshot(application)
         helper = TestHelper(application)
+        application.launchArguments = ["-disableAnimations"]
         application.launch()
     }
 

--- a/VLC-iOS-UITests/VLCiOSTestMenu.swift
+++ b/VLC-iOS-UITests/VLCiOSTestMenu.swift
@@ -14,59 +14,59 @@ import Foundation
 import XCTest
 
 class VLCiOSTestMenu: XCTestCase {
-    let app = XCUIApplication()
+    let application = XCUIApplication()
     var helper: TestHelper!
 
     override func setUp() {
         super.setUp()
 
         XCUIDevice.shared.orientation = .portrait
-        setupSnapshot(app)
-        helper = TestHelper(app)
-        app.launch()
+        setupSnapshot(application)
+        helper = TestHelper(application)
+        application.launch()
     }
 
     func testNavigationToAudioTab() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.audio)
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.audio])
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.audio])
     }
 
     func testNavigationToNetworkTab() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.localNetwork)
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.localNetwork])
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.localNetwork])
     }
 
     func testNavigationToVideoTab() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.video)
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.video])
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.video])
     }
 
     func testNavigationToSettingsTab() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.settings)
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.settings])
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.settings])
     }
 
     func testNavigationToCloudServices() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.localNetwork)
-        app.cells[VLCAccessibilityIdentifier.cloud].tap()
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.cloud])
+        application.cells[VLCAccessibilityIdentifier.cloud].tap()
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.cloud])
     }
 
     func testNavigationToDownloads() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.localNetwork)
-        app.cells[VLCAccessibilityIdentifier.downloads].tap()
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.downloads])
+        application.cells[VLCAccessibilityIdentifier.downloads].tap()
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.downloads])
     }
 
     func testNavigationToNetworkStream() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.localNetwork)
-        app.cells[VLCAccessibilityIdentifier.stream].tap()
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.stream])
+        application.cells[VLCAccessibilityIdentifier.stream].tap()
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.stream])
     }
 
     func testNavigationToAbout() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.settings)
-        app.cells[VLCAccessibilityIdentifier.about].tap()
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.about])
+        application.cells[VLCAccessibilityIdentifier.about].tap()
+        XCTAssertNotNil(application.navigationBars[VLCAccessibilityIdentifier.about])
     }
 }

--- a/VLC-iOS-UITests/VLCiOSTestVideoCodecs.swift
+++ b/VLC-iOS-UITests/VLCiOSTestVideoCodecs.swift
@@ -24,6 +24,7 @@ class VLCiOSTestVideoCodecs: XCTestCase {
         setupSnapshot(application)
         helper = TestHelper(application)
         setupSnapshot(application)
+        application.launchArguments = ["-disableAnimations"]
         application.launch()
     }
 

--- a/VLC-iOS-UITests/VLCiOSTestVideoCodecs.swift
+++ b/VLC-iOS-UITests/VLCiOSTestVideoCodecs.swift
@@ -14,17 +14,17 @@ import Foundation
 import XCTest
 
 class VLCiOSTestVideoCodecs: XCTestCase {
-    let app = XCUIApplication()
+    let application = XCUIApplication()
     var helper: TestHelper!
     
     override func setUp() {
         super.setUp()
         
         XCUIDevice.shared.orientation = .portrait
-        setupSnapshot(app)
-        helper = TestHelper(app)
-        setupSnapshot(app)
-        app.launch()
+        setupSnapshot(application)
+        helper = TestHelper(application)
+        setupSnapshot(application)
+        application.launch()
     }
 
     func testMovCodec() {
@@ -45,22 +45,22 @@ class VLCiOSTestVideoCodecs: XCTestCase {
 
     func stream(named fileName: String) {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.localNetwork)
-        app.cells[VLCAccessibilityIdentifier.stream].tap()
+        application.cells[VLCAccessibilityIdentifier.stream].tap()
 
-        let addressTextField = app.textFields["http://myserver.com/file.mkv"]
+        let addressTextField = application.textFields["http://myserver.com/file.mkv"]
         addressTextField.clearAndEnter(text: fileName)
-        app.buttons["Open Network Stream"].tap()
+        application.buttons["Open Network Stream"].tap()
         
-        let displayTime = app.navigationBars["VLCMovieView"].buttons["--:--"]
+        let displayTime = application.navigationBars["VLCMovieView"].buttons["--:--"]
         let zeroPredicate = NSPredicate(format: "exists == 0")
         expectation(for: zeroPredicate, evaluatedWith: displayTime, handler: nil)
 
         waitForExpectations(timeout: 20.0) { err in
             XCTAssertNil(err)
-            if !(self.app.buttons["Done"].exists) {
-                self.app.otherElements["Video Player Title"].tap()
+            if !(self.application.buttons["Done"].exists) {
+                self.application.otherElements["Video Player Title"].tap()
             }
-            let playPause = self.app.buttons[VLCAccessibilityIdentifier.playPause]
+            let playPause = self.application.buttons[VLCAccessibilityIdentifier.playPause]
             let onePredicate = NSPredicate(format: "exists == 1")
             self.expectation(for: onePredicate, evaluatedWith: playPause, handler: nil)
             self.waitForExpectations(timeout: 20.0, handler: nil)

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A52085620B3614000D5492D /* VLCAppDelegate+UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A52085520B3614000D5492D /* VLCAppDelegate+UITests.swift */; };
 		1D72DC00CD4A06E8789BD8F7 /* libPods-VLC-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FE1DEC7096649D63A308D86C /* libPods-VLC-tvOS.a */; };
 		26F1BFD01A770408001DF30C /* libMediaVLC.xml in Resources */ = {isa = PBXBuildFile; fileRef = 26F1BFCF1A770408001DF30C /* libMediaVLC.xml */; };
 		29125E5617492219003F03E5 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 29125E5417492219003F03E5 /* index.html */; };
@@ -467,6 +468,7 @@
 /* Begin PBXFileReference section */
 		018698905AC809BE4496D84D /* Pods-vlc-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-vlc-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-vlc-ios/Pods-vlc-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		090F2933E962C424E9A80ABB /* Pods-VLC-iOS-no-watch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOS-no-watch.release.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOS-no-watch/Pods-VLC-iOS-no-watch.release.xcconfig"; sourceTree = "<group>"; };
+		0A52085520B3614000D5492D /* VLCAppDelegate+UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "VLCAppDelegate+UITests.swift"; path = "Sources/VLCAppDelegate+UITests.swift"; sourceTree = "<group>"; };
 		1C7724AABC40B96010E01F65 /* Pods-VLC-iOS-no-watch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOS-no-watch.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOS-no-watch/Pods-VLC-iOS-no-watch.debug.xcconfig"; sourceTree = "<group>"; };
 		260624EB5BF9F1FBE58BF816 /* libPods-VLC for iOSUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VLC for iOSUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		268BDA7D1B4FE1E200D622DD /* backArrow_black.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = backArrow_black.png; path = ImportedSources/OneDrive/src/LiveSDK/Library/Internal/Resources/backArrow_black.png; sourceTree = SOURCE_ROOT; };
@@ -1742,6 +1744,7 @@
 				7D6B08BB174A72A900A05173 /* VLCConstants.h */,
 				7DBBF180183AB3B80009A339 /* VLCAppDelegate.h */,
 				7DBBF181183AB3B80009A339 /* VLCAppDelegate.m */,
+				0A52085520B3614000D5492D /* VLCAppDelegate+UITests.swift */,
 				7DF383B41BF20E4600D71A5C /* Network dialogs */,
 				7DBB788E1B305D8300894467 /* Keychain & random singletons */,
 				7D2339AB176DE70E008D223C /* Menu */,
@@ -3151,6 +3154,7 @@
 				7DC19B051868D1C400810BF7 /* VLCFirstStepsFifthPageViewController.m in Sources */,
 				DD3EFF311BDEBCE500B68579 /* VLCNetworkServerBrowserFTP.m in Sources */,
 				9BADAF45185FBD9D00108BD8 /* VLCFrostedGlasView.m in Sources */,
+				0A52085620B3614000D5492D /* VLCAppDelegate+UITests.swift in Sources */,
 				DDC10BE41AEE8EA700890DC3 /* VLCTimeNavigationTitleView.m in Sources */,
 				DD870E9A1CEF929A00BBD4FE /* VLCNetworkLoginViewFieldCell.m in Sources */,
 				418B145620179DF2000447AA /* VLCMediaData+VLCDragAndDrop.swift in Sources */,


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
There are currently no view animation related UI-Tests. Therefore it seems to be a good idea to disable view animation and speed up UI-Tests for ~25%.

Full list of code changes:
* Renamed constant "app" to "application"
* Implemented VLCAppDelegate extension for UITests
* Added launch argument `-disableAnimations` to disable animations for UI-Tests 

### WIP / Todo
- [ ] Fix screenshot related test that is currently always failing
- [ ] Adapt ui-tests (seems like there are timing issues due to faster UI)
