### PR TITLE
3.0: Fix show externally view chromecast

### DIFF
--- a/Resources/VLCMovieViewController~ipad.xib
+++ b/Resources/VLCMovieViewController~ipad.xib
@@ -31,9 +31,7 @@
                 <outlet property="playbackSpeedLabel" destination="181" id="194"/>
                 <outlet property="playbackSpeedSlider" destination="180" id="191"/>
                 <outlet property="playbackSpeedView" destination="176" id="197"/>
-                <outlet property="playingExternallyDescription" destination="124" id="132"/>
-                <outlet property="playingExternallyTitle" destination="125" id="133"/>
-                <outlet property="playingExternallyView" destination="123" id="131"/>
+                <outlet property="playingExternalView" destination="123" id="BVQ-JJ-Ckd"/>
                 <outlet property="resetVideoFilterButton" destination="142" id="175"/>
                 <outlet property="saturationLabel" destination="150" id="166"/>
                 <outlet property="saturationSlider" destination="149" id="168"/>
@@ -209,7 +207,7 @@
                         </button>
                     </subviews>
                 </view>
-                <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="123" userLabel="Playing Externally View">
+                <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="123" userLabel="Playing Externally View" customClass="VLCPlayingExternallyView" customModule="VLC_iOS" customModuleProvider="target">
                     <rect key="frame" x="184" y="312" width="400" height="400"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <subviews>
@@ -217,16 +215,16 @@
                             <rect key="frame" x="51" y="0.0" width="298" height="266"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         </imageView>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="TV Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="125">
-                            <rect key="frame" x="51" y="274" width="298" height="21"/>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="TV Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="125">
+                            <rect key="frame" x="10" y="274" width="380" height="21"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                             <color key="textColor" red="0.3803921569" green="0.3803921569" blue="0.3803921569" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="This video is playing on the TV" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="124">
-                            <rect key="frame" x="51" y="303" width="298" height="53"/>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="This video is playing on the TV" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="124">
+                            <rect key="frame" x="10" y="303" width="380" height="53"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -235,6 +233,10 @@
                         </label>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <connections>
+                        <outlet property="playingExternallyDescription" destination="124" id="Z9R-mg-THz"/>
+                        <outlet property="playingExternallyTitle" destination="125" id="mLx-iH-3bI"/>
+                    </connections>
                 </view>
                 <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Status Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="205" customClass="VLCStatusLabel">
                     <rect key="frame" x="224" y="799" width="320" height="21"/>
@@ -340,7 +342,7 @@
         </view>
     </objects>
     <resources>
-        <image name="PlayingExternally.png" width="261" height="195"/>
+        <image name="PlayingExternally.png" width="16" height="16"/>
         <image name="resetIcon.png" width="24" height="30"/>
     </resources>
 </document>

--- a/Resources/VLCMovieViewController~iphone.xib
+++ b/Resources/VLCMovieViewController~iphone.xib
@@ -31,9 +31,7 @@
                 <outlet property="playbackSpeedLabel" destination="167" id="198"/>
                 <outlet property="playbackSpeedSlider" destination="168" id="M6M-8F-t8T"/>
                 <outlet property="playbackSpeedView" destination="165" id="208"/>
-                <outlet property="playingExternallyDescription" destination="109" id="113"/>
-                <outlet property="playingExternallyTitle" destination="110" id="114"/>
-                <outlet property="playingExternallyView" destination="108" id="112"/>
+                <outlet property="playingExternalView" destination="108" id="xbW-U2-ESN"/>
                 <outlet property="resetVideoFilterButton" destination="162" id="163"/>
                 <outlet property="saturationLabel" destination="136" id="155"/>
                 <outlet property="saturationSlider" destination="135" id="152"/>
@@ -51,15 +49,15 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="yK6-Ph-SVE">
-                    <rect key="frame" x="40" y="164" width="240" height="240"/>
+                    <rect key="frame" x="68" y="214" width="240" height="240"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                 </imageView>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Album Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" adjustsLetterSpacingToFitWidth="YES" id="280">
-                    <rect key="frame" x="31" y="336" width="258" height="28"/>
+                    <rect key="frame" x="31" y="397" width="313" height="28"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <color key="textColor" red="0.72000002861022949" green="0.72000002861022949" blue="0.72000002861022949" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -67,14 +65,14 @@
                     <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </label>
                 <view contentMode="scaleToFill" id="91" userLabel="Movie view">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <accessibility key="accessibilityConfiguration">
                         <bool key="isElement" value="YES"/>
                     </accessibility>
                 </view>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" misplaced="YES" text="Track Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsLetterSpacingToFitWidth="YES" id="282">
-                    <rect key="frame" x="31" y="415" width="257" height="28"/>
+                    <rect key="frame" x="31" y="491" width="312" height="28"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="23"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -82,7 +80,7 @@
                     <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </label>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" text="Artist Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsLetterSpacingToFitWidth="YES" id="279">
-                    <rect key="frame" x="31" y="267" width="257" height="28"/>
+                    <rect key="frame" x="31" y="316" width="312" height="28"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="23"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -90,31 +88,31 @@
                     <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </label>
                 <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Status Label" textAlignment="center" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" id="210" customClass="VLCStatusLabel">
-                    <rect key="frame" x="61" y="273" width="199" height="22"/>
+                    <rect key="frame" x="89" y="323" width="199" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                     <color key="shadowColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                 </label>
-                <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="108" userLabel="Playing Externally View">
-                    <rect key="frame" x="0.0" y="135" width="320" height="257"/>
+                <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="108" userLabel="Playing Externally View" customClass="VLCPlayingExternallyView" customModule="VLC_iOS" customModuleProvider="target">
+                    <rect key="frame" x="28" y="178" width="320" height="257"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" image="PlayingExternally.png" id="111">
                             <rect key="frame" x="80" y="20" width="160" height="130"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         </imageView>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="TV Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="110">
-                            <rect key="frame" x="20" y="170" width="280" height="21"/>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="TV Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="110">
+                            <rect key="frame" x="10" y="170" width="300" height="21"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                             <color key="textColor" red="0.3803921569" green="0.3803921569" blue="0.3803921569" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="This video is playing on the TV" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="109">
-                            <rect key="frame" x="20" y="199" width="289" height="53"/>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="This video is playing on the TV" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="109">
+                            <rect key="frame" x="10" y="199" width="300" height="53"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -123,20 +121,24 @@
                         </label>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <connections>
+                        <outlet property="playingExternallyDescription" destination="109" id="fXx-Nb-GGd"/>
+                        <outlet property="playingExternallyTitle" destination="110" id="7Bd-9p-QXk"/>
+                    </connections>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" id="241" userLabel="scrubbing indicator view" customClass="VLCFrostedGlasView">
-                    <rect key="frame" x="0.0" y="63" width="320" height="46"/>
+                    <rect key="frame" x="0.0" y="63" width="375" height="46"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <subviews>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="High-Speed Scrubbing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="244">
-                            <rect key="frame" x="20" y="3" width="280" height="21"/>
+                            <rect key="frame" x="20" y="3" width="335" height="21"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Slide your finger down to adjust the scrubbing rate." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" id="246">
-                            <rect key="frame" x="0.0" y="21" width="320" height="21"/>
+                            <rect key="frame" x="0.0" y="21" width="375" height="21"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -146,7 +148,7 @@
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.60999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" id="117" userLabel="video filters view" customClass="VLCFrostedGlasView">
-                    <rect key="frame" x="0.0" y="342" width="320" height="198"/>
+                    <rect key="frame" x="28" y="441" width="320" height="198"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="2" id="128" customClass="VLCSlider">
@@ -237,7 +239,7 @@
                     </subviews>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" misplaced="YES" id="165" userLabel="speed delay Controls panel" customClass="VLCFrostedGlasView">
-                    <rect key="frame" x="0.0" y="294" width="320" height="163"/>
+                    <rect key="frame" x="28" y="393" width="320" height="163"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Audio delay" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8cb-fw-YeF">
@@ -341,7 +343,7 @@
         </view>
     </objects>
     <resources>
-        <image name="PlayingExternally.png" width="122" height="91"/>
+        <image name="PlayingExternally.png" width="16" height="16"/>
         <image name="resetIcon.png" width="24" height="30"/>
     </resources>
 </document>

--- a/Resources/VLCPlayingExternallyView.xib
+++ b/Resources/VLCPlayingExternallyView.xib
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VLCPlayExternallyController" customModule="VLC_iOS" customModuleProvider="target">
+            <connections>
+                <outlet property="playingExternallyView" destination="Jhp-Wu-Cyf" id="RR8-dQ-7yL"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="Jhp-Wu-Cyf" userLabel="Playing Externally View" customClass="VLCPlayingExternallyView" customModule="VLC_iOS" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" image="PlayingExternally.png" translatesAutoresizingMaskIntoConstraints="NO" id="CIh-qH-85s">
+                    <rect key="frame" x="108" y="20" width="160" height="130"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                </imageView>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="TV Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R6g-jM-6Ym">
+                    <rect key="frame" x="38" y="170" width="300" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
+                    <color key="textColor" red="0.3803921569" green="0.3803921569" blue="0.3803921569" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="This video is playing on the TV" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UbH-6k-6hM">
+                    <rect key="frame" x="38" y="199" width="300" height="53"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                    <color key="textColor" red="0.3803921569" green="0.3803921569" blue="0.3803921569" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="highlightedColor" red="0.3803921569" green="0.3803921569" blue="0.3803921569" alpha="0.81000000000000005" colorSpace="custom" customColorSpace="sRGB"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="FRP-Rv-V1R"/>
+            <connections>
+                <outlet property="playingExternallyDescription" destination="UbH-6k-6hM" id="hCM-jy-NE0"/>
+                <outlet property="playingExternallyTitle" destination="R6g-jM-6Ym" id="3uP-nO-Yij"/>
+            </connections>
+            <point key="canvasLocation" x="122" y="-38"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="PlayingExternally.png" width="16" height="16"/>
+    </resources>
+</document>

--- a/SharedSources/VLCPlayingExternallyView.swift
+++ b/SharedSources/VLCPlayingExternallyView.swift
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * VLCPlayingExternallyView.swift
+ * VLC for iOS
+ *****************************************************************************
+ * Copyright (c) 2018 VideoLAN. All rights reserved.
+ * $Id$
+ *
+ * Authors: Carola Nitz <caro # videolan.org>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
+
+import Foundation
+
+class VLCPlayingExternallyView: UIView {
+
+    @IBOutlet weak var playingExternallyTitle: UILabel!
+    @IBOutlet weak var playingExternallyDescription: UILabel!
+    @objc var displayView: UIView? {
+        return externalWindow?.rootViewController?.view
+    }
+    var externalWindow:UIWindow?
+
+    @objc func shouldDisplay(_ show:Bool) {
+        self.isHidden = !show
+        externalWindow?.isHidden = !show
+        if show {
+            guard let screen = UIScreen.screens.count > 1 ? UIScreen.screens[1] : nil else {
+                return
+            }
+            screen.overscanCompensation = .none
+            externalWindow = UIWindow(frame: screen.bounds)
+            guard let externalWindow = externalWindow else {
+                return
+            }
+            externalWindow.rootViewController = VLCExternalDisplayController()
+            externalWindow.screen = screen
+            externalWindow.rootViewController?.view.frame = externalWindow.bounds
+        } else {
+            externalWindow = nil
+        }
+    }
+
+    override func awakeFromNib() {
+        playingExternallyTitle.text = NSLocalizedString("PLAYING_EXTERNALLY_TITLE", comment: "")
+        playingExternallyDescription.text = NSLocalizedString("PLAYING_EXTERNALLY_DESC", comment:"")
+    }
+
+    @objc func updateUI(rendererItem:VLCRendererItem?) {
+        if let rendererItem = rendererItem {
+            playingExternallyTitle.text = NSLocalizedString("PLAYING_EXTERNALLY_TITLE_CHROMECAST", comment:"")
+            playingExternallyDescription.text = rendererItem.name;
+        } else {
+            playingExternallyTitle.text = NSLocalizedString("PLAYING_EXTERNALLY_TITLE", comment: "")
+            playingExternallyDescription.text = NSLocalizedString("PLAYING_EXTERNALLY_DESC", comment:"")
+        }
+    }
+}

--- a/Sources/VLCMovieViewController.h
+++ b/Sources/VLCMovieViewController.h
@@ -35,10 +35,6 @@ typedef NS_ENUM(NSInteger, VLCMovieJumpState) {
 @property (nonatomic, strong) IBOutlet UIButton *sleepTimerButton;
 @property (nonatomic, strong) IBOutlet VLCStatusLabel *statusLabel;
 
-@property (nonatomic, strong) IBOutlet UIView *playingExternallyView;
-@property (nonatomic, strong) IBOutlet UILabel *playingExternallyTitle;
-@property (nonatomic, strong) IBOutlet UILabel *playingExternallyDescription;
-
 @property (nonatomic, strong) IBOutlet VLCFrostedGlasView *videoFilterView;
 @property (nonatomic, strong) IBOutlet UILabel *hueLabel;
 @property (nonatomic, strong) IBOutlet UISlider *hueSlider;
@@ -95,7 +91,5 @@ typedef NS_ENUM(NSInteger, VLCMovieJumpState) {
 - (void)toggleUILock;
 - (void)toggleChapterAndTitleSelector;
 - (void)hideMenu;
-
-- (void)setupCastWithCurrentRenderer;
 
 @end

--- a/Sources/VLCPlaybackController.h
+++ b/Sources/VLCPlaybackController.h
@@ -136,6 +136,4 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
 - (void)playMediaList:(VLCMediaList *)mediaList firstIndex:(NSInteger)index subtitlesFilePath:(NSString *)subsFilePath;
 - (void)openVideoSubTitlesFromFile:(NSString *)pathToFile;
 
-- (void)mediaPlayerSetRenderer:(VLCRendererItem *)renderer;
-
 @end

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1326,10 +1326,10 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
 }
 
 #pragma mark - Renderer
-
-- (void)mediaPlayerSetRenderer:(VLCRendererItem *)renderer
+- (void)setRenderer:(VLCRendererItem *)renderer
 {
-    [_mediaPlayer setRendererItem:renderer];
+    _renderer = renderer;
+    [_mediaPlayer setRendererItem:_renderer];
 }
 
 @end

--- a/VLC-iOS-Bridging-Header.h
+++ b/VLC-iOS-Bridging-Header.h
@@ -10,5 +10,6 @@
 #import <PAPasscode/PAPasscodeViewController.h>
 #import <XKKeychain/XKKeychain.h>
 #import "VLCConstants.h"
+#import "VLCExternalDisplayController.h"
 #import "VLCPlaybackController.h"
 #import "UIColor+Presets.h"

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -16,9 +16,10 @@
 		412BE7531FC4947400ACCC42 /* VLCMediaData+VLCDragAndDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412BE7521FC4947400ACCC42 /* VLCMediaData+VLCDragAndDrop.swift */; };
 		4144C4661A0ED6C700918C89 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D3784E6183A99E1009EE944 /* Reachability.m */; };
 		4152F1621FEF19BD00F1908B /* KeychainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4152F1611FEF19BD00F1908B /* KeychainCoordinator.swift */; };
+		416443862048419E00CAC646 /* DeviceMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416443852048419E00CAC646 /* DeviceMotion.swift */; };
+		416DACB720B6DB9A001BC75D /* VLCPlayingExternallyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416DACB620B6DB9A001BC75D /* VLCPlayingExternallyView.swift */; };
 		416DEFF61FEEA76A00F4FC59 /* LayoutAnchorContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416DEFF51FEEA76A00F4FC59 /* LayoutAnchorContainer.swift */; };
 		4171D35018A2C19000A16EF9 /* VLCFolderCollectionViewFlowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 4171D34F18A2C19000A16EF9 /* VLCFolderCollectionViewFlowLayout.m */; };
-		416443862048419E00CAC646 /* DeviceMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416443852048419E00CAC646 /* DeviceMotion.swift */; };
 		417CDA231A48D1F300D9ACE7 /* VLCCloudServicesTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 417CDA211A48D1F300D9ACE7 /* VLCCloudServicesTableViewController.m */; };
 		417CDA241A48D1F300D9ACE7 /* VLCCloudServicesTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 417CDA221A48D1F300D9ACE7 /* VLCCloudServicesTableViewController.xib */; };
 		417D7F601F7BA26200DDF36A /* VLCRemoteControlService.m in Sources */ = {isa = PBXBuildFile; fileRef = 417D7F5F1F7BA26200DDF36A /* VLCRemoteControlService.m */; };
@@ -748,6 +749,7 @@
 		412BE7521FC4947400ACCC42 /* VLCMediaData+VLCDragAndDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "VLCMediaData+VLCDragAndDrop.swift"; path = "Sources/VLCMediaData+VLCDragAndDrop.swift"; sourceTree = SOURCE_ROOT; };
 		4152F1611FEF19BD00F1908B /* KeychainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KeychainCoordinator.swift; path = Sources/KeychainCoordinator.swift; sourceTree = "<group>"; };
 		416443852048419E00CAC646 /* DeviceMotion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeviceMotion.swift; path = Sources/DeviceMotion.swift; sourceTree = "<group>"; };
+		416DACB620B6DB9A001BC75D /* VLCPlayingExternallyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCPlayingExternallyView.swift; sourceTree = "<group>"; };
 		416DEFF51FEEA76A00F4FC59 /* LayoutAnchorContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LayoutAnchorContainer.swift; path = Sources/LayoutAnchorContainer.swift; sourceTree = "<group>"; };
 		4171D34E18A2C19000A16EF9 /* VLCFolderCollectionViewFlowLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VLCFolderCollectionViewFlowLayout.h; path = Sources/VLCFolderCollectionViewFlowLayout.h; sourceTree = SOURCE_ROOT; };
 		4171D34F18A2C19000A16EF9 /* VLCFolderCollectionViewFlowLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VLCFolderCollectionViewFlowLayout.m; path = Sources/VLCFolderCollectionViewFlowLayout.m; sourceTree = SOURCE_ROOT; };
@@ -2758,6 +2760,7 @@
 				417E68B81F321EFF00DB9BB2 /* VLCActivityViewControllerVendor.m */,
 				41EB91DB1F7BFF8400821AA5 /* VLCMetadata.h */,
 				41EB91DC1F7BFF8400821AA5 /* VLCMetadata.m */,
+				416DACB620B6DB9A001BC75D /* VLCPlayingExternallyView.swift */,
 			);
 			path = SharedSources;
 			sourceTree = "<group>";
@@ -3951,6 +3954,7 @@
 				7D3784C2183A9938009EE944 /* VLCSlider.m in Sources */,
 				7D3784C3183A9938009EE944 /* VLCStatusLabel.m in Sources */,
 				7D1276621AADA0E600F0260C /* VLCMultiSelectionMenuView.m in Sources */,
+				416DACB720B6DB9A001BC75D /* VLCPlayingExternallyView.swift in Sources */,
 				7D3784C8183A9972009EE944 /* NSString+SupportedMedia.m in Sources */,
 				417E68B91F321EFF00DB9BB2 /* VLCActivityViewControllerVendor.m in Sources */,
 				DD3EFF5B1BDEBCE500B68579 /* VLCNetworkServerBrowserUPnP.m in Sources */,


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This fixes that 
- the playing externally was overlapping when you started the Chromecast
- playing externally wasn't shown for audio files
