### PR TITLE
UINavigationBar: change the style to adapt with a themechange

### DIFF
--- a/SharedSources/PresentationTheme.swift
+++ b/SharedSources/PresentationTheme.swift
@@ -20,6 +20,9 @@ extension Notification.Name {
 
     public let isDark: Bool
     public let name: String
+    public let statusBarStyle: UIStatusBarStyle
+    public let navigationbarColor: UIColor
+    public let navigationbarTextColor: UIColor
     public let background: UIColor
     public let cellBackgroundA: UIColor
     public let cellBackgroundB: UIColor
@@ -36,6 +39,9 @@ extension Notification.Name {
 
     public init(isDark: Bool,
                 name: String,
+                statusBarStyle:UIStatusBarStyle,
+                navigationbarColor: UIColor,
+                navigationbarTextColor: UIColor,
                 background: UIColor,
                 cellBackgroundA: UIColor,
                 cellBackgroundB: UIColor,
@@ -51,6 +57,9 @@ extension Notification.Name {
                 orangeUI: UIColor) {
         self.isDark = isDark
         self.name = name
+        self.statusBarStyle = statusBarStyle
+        self.navigationbarColor = navigationbarColor
+        self.navigationbarTextColor = navigationbarTextColor
         self.background = background
         self.cellBackgroundA = cellBackgroundA
         self.cellBackgroundB = cellBackgroundB
@@ -77,8 +86,8 @@ extension Notification.Name {
         return isDarkTheme ? PresentationTheme.darkTheme : PresentationTheme.brightTheme
     }() {
         didSet {
-            NotificationCenter.default.post(name: .VLCThemeDidChangeNotification, object: self)
             AppearanceManager.setupAppearance(theme: self.current)
+            NotificationCenter.default.post(name: .VLCThemeDidChangeNotification, object: self)
         }
     }
 
@@ -126,6 +135,9 @@ extension Notification.Name {
 
 let brightPalette = ColorPalette(isDark: false,
                                  name: "Default",
+                                 statusBarStyle: .default,
+                                 navigationbarColor: UIColor(0xFFFFFF),
+                                 navigationbarTextColor: UIColor(0x000000),
                                  background: UIColor(0xF9F9F7),
                                  cellBackgroundA: UIColor(0xF9F9F7),
                                  cellBackgroundB: UIColor(0xE5E5E3),
@@ -142,6 +154,9 @@ let brightPalette = ColorPalette(isDark: false,
 
 let darkPalette = ColorPalette(isDark: true,
                                name: "Dark",
+                               statusBarStyle: .lightContent,
+                               navigationbarColor: UIColor(0x292B36),
+                               navigationbarTextColor: UIColor(0xD3D3D3),
                                background: UIColor(0x292B36),
                                cellBackgroundA: UIColor(0x292B36),
                                cellBackgroundB: UIColor(0x000000),
@@ -153,5 +168,5 @@ let darkPalette = ColorPalette(isDark: true,
                                settingsBackground: UIColor(0x292B36),
                                settingsCellBackground: UIColor(0x3D3F40),
                                settingsSeparatorColor: UIColor(0xA9A9A9),
-                               tabBarColor: UIColor(0xFFFFFF),
+                               tabBarColor: UIColor(0x292B36),
                                orangeUI: UIColor(0xFF8800))

--- a/Sources/AppearanceManager.swift
+++ b/Sources/AppearanceManager.swift
@@ -21,18 +21,18 @@ class AppearanceManager: NSObject {
         UITextField.appearance().tintColor = theme.colors.orangeUI
 
         // Don't override the 'Cancel' button color in the search bar with the previous UITextField call. Use the default blue color
-        let attributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
+        let attributes = [NSAttributedStringKey.foregroundColor: theme.colors.orangeUI]
         UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]).setTitleTextAttributes(attributes, for: .normal)
 
-        UINavigationBar.appearance().barTintColor = theme.colors.orangeUI
+        UINavigationBar.appearance().barTintColor = theme.colors.navigationbarColor
         UINavigationBar.appearance(whenContainedInInstancesOf: [VLCPlaybackNavigationController.self]).barTintColor = nil
-        UINavigationBar.appearance().tintColor = .white
-        UINavigationBar.appearance().titleTextAttributes = attributes
+        UINavigationBar.appearance().tintColor = theme.colors.orangeUI
+        UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.foregroundColor: theme.colors.navigationbarTextColor]
 
         if #available(iOS 11.0, *) {
             UINavigationBar.appearance().prefersLargeTitles = true
             UINavigationBar.appearance(whenContainedInInstancesOf: [VLCPlaybackNavigationController.self]).prefersLargeTitles = false
-            UINavigationBar.appearance().largeTitleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
+            UINavigationBar.appearance().largeTitleTextAttributes = [NSAttributedStringKey.foregroundColor: theme.colors.navigationbarTextColor]
         }
         // For the edit selection indicators
         UITableView.appearance().tintColor = theme.colors.orangeUI
@@ -41,5 +41,12 @@ class AppearanceManager: NSObject {
         UISearchBar.appearance().barTintColor = .white
 
         UITabBar.appearance().tintColor = theme.colors.orangeUI
+    }
+}
+
+//extensions so that preferredStatusBarStyle is called on all childViewControllers otherwise this is not forwarded
+extension UINavigationController {
+    override open var childViewControllerForStatusBarStyle: UIViewController? {
+        return self.topViewController
     }
 }

--- a/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
@@ -295,6 +295,7 @@
     _scrollView.backgroundColor = PresentationTheme.current.colors.background;
     _localNetworkTableView.separatorColor = PresentationTheme.current.colors.background;
     _refreshControl.backgroundColor = PresentationTheme.current.colors.background;
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)_dismissLogin
@@ -303,6 +304,11 @@
         [self.navigationController popViewControllerAnimated:YES];
     else
         [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return PresentationTheme.current.colors.statusBarStyle;
 }
 
 #pragma mark - Refresh

--- a/Sources/MediaViewController.swift
+++ b/Sources/MediaViewController.swift
@@ -60,6 +60,10 @@ public class VLCMediaViewController: UICollectionViewController, UISearchResults
         }
     }
 
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        return PresentationTheme.current.colors.statusBarStyle
+    }
+
     @objc func reloadData() {
         collectionView?.reloadData()
         updateUIForContent()
@@ -91,6 +95,8 @@ public class VLCMediaViewController: UICollectionViewController, UISearchResults
 
     @objc func themeDidChange() {
         collectionView?.backgroundColor = PresentationTheme.current.colors.background
+        setNeedsStatusBarAppearanceUpdate()
+
     }
 
     func setupCollectionView() {

--- a/Sources/VLC for iOS-Info.plist
+++ b/Sources/VLC for iOS-Info.plist
@@ -291,27 +291,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleLightContent</string>
-	<key>UIStatusBarTintParameters</key>
-	<dict>
-		<key>UINavigationBar</key>
-		<dict>
-			<key>Style</key>
-			<string>UIBarStyleBlack</string>
-			<key>TintColor</key>
-			<dict>
-				<key>Blue</key>
-				<integer>0</integer>
-				<key>Green</key>
-				<real>0.5</real>
-				<key>Red</key>
-				<integer>1</integer>
-			</dict>
-			<key>Translucent</key>
-			<true/>
-		</dict>
-	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -327,7 +306,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/Sources/VLCCloudServicesTableViewController.m
+++ b/Sources/VLCCloudServicesTableViewController.m
@@ -64,6 +64,7 @@
 {
     self.tableView.separatorColor = PresentationTheme.current.colors.background;
     self.tableView.backgroundColor = PresentationTheme.current.colors.background;
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -95,6 +96,11 @@
     i += [[BoxSDK sharedSDK].OAuth2Session isAuthorized] ? 1 : 0;
     i += [[VLCOneDriveController sharedInstance] isAuthorized] ? 1 : 0;
     return i;
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return PresentationTheme.current.colors.statusBarStyle;
 }
 
 - (UIImage *)cellImage

--- a/Sources/VLCDownloadViewController.m
+++ b/Sources/VLCDownloadViewController.m
@@ -116,6 +116,12 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
     self.speedRate.textColor =  PresentationTheme.current.colors.cellBackgroundB;
     self.timeDL.textColor = PresentationTheme.current.colors.cellTextColor;
     [self.downloadsTable reloadData];
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return PresentationTheme.current.colors.statusBarStyle;
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -505,7 +505,6 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
         _idleTimer = nil;
     }
 
-    [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
     [super viewWillDisappear:animated];
 
     // hide filter UI for next run
@@ -762,11 +761,27 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
         self->_trackNameLabel.hidden =  self->_audioOnly ? NO : self->_controlsHidden;
     };
 
-    UIStatusBarAnimation animationType = animated? UIStatusBarAnimationFade: UIStatusBarAnimationNone;
-    NSTimeInterval animationDuration = animated? 0.3: 0.0;
+    NSTimeInterval animationDuration = animated? 0.3 : 0.0;
+    [UIView animateWithDuration:animationDuration animations:^{
+        [self setNeedsStatusBarAppearanceUpdate];
+    }];
 
-    [[UIApplication sharedApplication] setStatusBarHidden:_viewAppeared ? _controlsHidden : NO withAnimation:animationType];
     [UIView animateWithDuration:animationDuration animations:animationBlock completion:completionBlock];
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+    return _viewAppeared ? _controlsHidden : NO;
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+    return UIStatusBarAnimationFade;
 }
 
 - (void)toggleControlsVisible

--- a/Sources/VLCOpenNetworkStreamViewController.m
+++ b/Sources/VLCOpenNetworkStreamViewController.m
@@ -152,6 +152,12 @@
     self.whatToOpenHelpLabel.textColor = PresentationTheme.current.colors.lightTextColor;
     self.openButton.backgroundColor = PresentationTheme.current.colors.orangeUI;
     [self.historyTableView reloadData];
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return PresentationTheme.current.colors.statusBarStyle;
 }
 
 - (void)updatePasteboardTextInURLField

--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -47,12 +47,18 @@
     self.view.backgroundColor = PresentationTheme.current.colors.settingsBackground;
     self.tableView.separatorColor = PresentationTheme.current.colors.settingsSeparatorColor;
     [self.tableView reloadData];
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
     [self filterCellsWithAnimation:NO];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return PresentationTheme.current.colors.statusBarStyle;
 }
 
 - (NSSet *)hiddenBiometryKeys

--- a/Sources/VLCTabBarCoordinator.swift
+++ b/Sources/VLCTabBarCoordinator.swift
@@ -33,7 +33,19 @@ class VLCTabbarCooordinator: NSObject, VLCMediaViewControllerDelegate {
     }
 
     @objc func updateTheme() {
+        //Setting this in appearanceManager doesn't update tabbar and UINavigationbar of the settingsViewController on change hence we do it here
         tabBarController.tabBar.barTintColor = PresentationTheme.current.colors.tabBarColor
+        tabBarController.viewControllers?.forEach {
+            if let navController = $0 as? UINavigationController, navController.topViewController is VLCSettingsController {
+                navController.navigationBar.barTintColor =  PresentationTheme.current.colors.navigationbarColor
+                navController.navigationBar.tintColor =  PresentationTheme.current.colors.orangeUI
+                navController.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
+
+                if #available(iOS 11.0, *) {
+                    navController.navigationBar.largeTitleTextAttributes = [NSAttributedStringKey.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
+                }
+            }
+        }
     }
 
     func setupViewControllers() {


### PR DESCRIPTION
This also makes every ViewController responsible for the correct statusbarstyle,
which also changes with a theme change

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
- we have a white and dark navigation bar 
- the statusbar warnings are resolved 
- every viewcontroller controls the statusbar style which needs to be done to update on theme changes