### PR TITLE
SwiftLint script phase integration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,7 @@ whitelist_rules:
   - opening_brace
   - operator_whitespace
   - private_unit_test
-  - redundant_nil_coalesing
+  - redundant_nil_coalescing
   - redundant_string_enum_value
   - return_arrow_whitespace
   - syntactic_sugar

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,9 @@ def shared_pods
   pod 'VLC-WhiteRaccoon'
   pod 'VLC-LiveSDK', '5.7.0x'
   pod 'ObjectiveDropboxOfficial', :git => 'git://github.com/carolanitz/dropbox-sdk-obj-c.git' #update ios platform version
-  pod 'SwiftLint', '~> 0.25.0'
+
+  # debug
+  pod 'SwiftLint', '~> 0.25.0', :configurations => ['Debug']
 end
 
 target 'VLC-iOS' do

--- a/SharedSources/PresentationTheme.swift
+++ b/SharedSources/PresentationTheme.swift
@@ -39,7 +39,7 @@ extension Notification.Name {
 
     public init(isDark: Bool,
                 name: String,
-                statusBarStyle:UIStatusBarStyle,
+                statusBarStyle: UIStatusBarStyle,
                 navigationbarColor: UIColor,
                 navigationbarTextColor: UIColor,
                 background: UIColor,

--- a/Sources/VLCTabBarCoordinator.swift
+++ b/Sources/VLCTabBarCoordinator.swift
@@ -37,8 +37,8 @@ class VLCTabbarCooordinator: NSObject, VLCMediaViewControllerDelegate {
         tabBarController.tabBar.barTintColor = PresentationTheme.current.colors.tabBarColor
         tabBarController.viewControllers?.forEach {
             if let navController = $0 as? UINavigationController, navController.topViewController is VLCSettingsController {
-                navController.navigationBar.barTintColor =  PresentationTheme.current.colors.navigationbarColor
-                navController.navigationBar.tintColor =  PresentationTheme.current.colors.orangeUI
+                navController.navigationBar.barTintColor = PresentationTheme.current.colors.navigationbarColor
+                navController.navigationBar.tintColor = PresentationTheme.current.colors.orangeUI
                 navController.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
 
                 if #available(iOS 11.0, *) {

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -2473,6 +2473,7 @@
 			buildConfigurationList = 7D94FD0A16DE7D1100F2623B /* Build configuration list for PBXNativeTarget "VLC-iOS" */;
 			buildPhases = (
 				23B425DEB65EA5C88D873ED2 /* [CP] Check Pods Manifest.lock */,
+				0A9D17D120C4A14700AA4A8C /* Run SwiftLint Script */,
 				7D94FCD716DE7D1000F2623B /* Sources */,
 				7D94FCD816DE7D1000F2623B /* Frameworks */,
 				7D94FCD916DE7D1000F2623B /* Resources */,
@@ -2832,6 +2833,20 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-VLC-tvOS/Pods-VLC-tvOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		0A9D17D120C4A14700AA4A8C /* Run SwiftLint Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint";
 		};
 		23B425DEB65EA5C88D873ED2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description

I added SwiftLint as a script to the vlc-ios build phase to show warnings at the build.
There was also a typo in the SwiftLint configuration (`configuration error: 'redundant_nil_coalesing' is not a valid rule identifier`) is now `redundant_nil_coalescing`.
And i changed the SwiftLint pod configuration to debug / fixed some SwiftLint realted warnings.

Full list of code changes:
* Added SwiftLint script phase
* Added debug configuration for SwiftLint pod
* Fixed typo in SwiftLint configuration
  Reason: configuration error: 'redundant_nil_coalesing' is not a valid rule identifier
* Fixed SwiftLinit related warnings
