### PR TITLE
VLCTabBarCoordinator: Change tab order

### DIFF
--- a/Sources/VLCTabBarCoordinator.swift
+++ b/Sources/VLCTabBarCoordinator.swift
@@ -94,7 +94,7 @@ class VLCTabbarCooordinator: NSObject, VLCMediaViewControllerDelegate {
             selectedImage: UIImage(named: "Settings"))
         settingsVC.tabBarItem.accessibilityIdentifier = VLCAccessibilityIdentifier.settings
 
-        let controllers = [audioVC, serverVC, videoVC, settingsVC]
+        let controllers = [videoVC, audioVC, serverVC, settingsVC]
         tabBarController.viewControllers = controllers.map { UINavigationController(rootViewController: $0) }
     }
 


### PR DESCRIPTION
Move the Video tab to first posisiton

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Move the video tab to first position according to the new design.