### PR TITLE
libvlc_MetadataCancel_Issue

### DIFF
--- a/SharedSources/ServerBrowsing/UIViewController+VLCAlert.m
+++ b/SharedSources/ServerBrowsing/UIViewController+VLCAlert.m
@@ -23,8 +23,7 @@
 - (void)vlc_showAlertWithTitle:(NSString *)title message:(NSString *)message buttonTitle:(NSString *)buttonTitle
     {
         NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: buttonTitle
-                                                                                  action: ^(UIAlertAction* action){}]
-                                                   ];
+                                                                                  action: nil]];
         [VLCAlertViewController alertViewManagerWithTitle:title
                                              errorMessage:message
                                            viewController:self

--- a/SharedSources/ServerBrowsing/UIViewController+VLCAlert.m
+++ b/SharedSources/ServerBrowsing/UIViewController+VLCAlert.m
@@ -10,7 +10,7 @@
  *****************************************************************************/
 
 #import "UIViewController+VLCAlert.h"
-
+#import "VLC_iOS-Swift.h"
 @implementation UIViewController (UIViewController_VLCAlert)
 #if TARGET_OS_TV
 - (void)vlc_showAlertWithTitle:(NSString *)title message:(NSString *)message buttonTitle:(NSString *)buttonTitle
@@ -22,12 +22,14 @@
 #else
 - (void)vlc_showAlertWithTitle:(NSString *)title message:(NSString *)message buttonTitle:(NSString *)buttonTitle
     {
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:title
-                                                      message:message
-                                                     delegate:self
-                                            cancelButtonTitle:buttonTitle
-                                            otherButtonTitles:nil];
-    [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: buttonTitle
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:title
+                                             errorMessage:message
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
 }
 #endif
 @end

--- a/SharedSources/ServerBrowsing/UIViewController+VLCAlert.m
+++ b/SharedSources/ServerBrowsing/UIViewController+VLCAlert.m
@@ -22,10 +22,9 @@
 #else
 - (void)vlc_showAlertWithTitle:(NSString *)title message:(NSString *)message buttonTitle:(NSString *)buttonTitle
     {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: buttonTitle
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
+        NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: buttonTitle
+                                                                                  action: ^(UIAlertAction* action){}]
+                                                   ];
         [VLCAlertViewController alertViewManagerWithTitle:title
                                              errorMessage:message
                                            viewController:self

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
@@ -172,11 +172,12 @@
     self.loginInformation = login;
     NSError *error = nil;
     if (![self.savedLoginsDataSource saveLogin:login error:&error]) {
-
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil) buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
-        [VLCAlertViewController alertViewManagerWithTitle:error.localizedDescription errorMessage: error.localizedFailureReason viewController:self buttonsAction:buttonsAction];
+        [VLCAlertViewController alertViewManagerWithTitle:error.localizedDescription
+                                             errorMessage: error.localizedFailureReason
+                                           viewController:self
+                                            buttonsAction:@[[[VLCAlertButton alloc]
+                                                             initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                             action: ^(UIAlertAction* action){}]]];
     }
 
     [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
@@ -198,19 +199,14 @@
 - (BOOL)protocolSelected
 {
     if (self.protocolDataSource.protocol == VLCServerProtocolUndefined) {
-
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
                                              errorMessage: NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
                                            viewController:self
-                                            buttonsAction:buttonsAction];
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                         action: ^(UIAlertAction* action){}]]];
         [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
         return NO;
     }
-
     return YES;
 }
 

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
@@ -173,11 +173,9 @@
     NSError *error = nil;
     if (![self.savedLoginsDataSource saveLogin:login error:&error]) {
         [VLCAlertViewController alertViewManagerWithTitle:error.localizedDescription
-                                             errorMessage: error.localizedFailureReason
+                                             errorMessage:error.localizedFailureReason
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc]
-                                                             initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                             action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
     }
 
     [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
@@ -200,10 +198,9 @@
 {
     if (self.protocolDataSource.protocol == VLCServerProtocolUndefined) {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
-                                             errorMessage: NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
+                                             errorMessage:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                         action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
         [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
         return NO;
     }

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
@@ -174,8 +174,7 @@
     if (![self.savedLoginsDataSource saveLogin:login error:&error]) {
         [VLCAlertViewController alertViewManagerWithTitle:error.localizedDescription
                                              errorMessage:error.localizedFailureReason
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
     }
 
     [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
@@ -199,8 +198,7 @@
     if (self.protocolDataSource.protocol == VLCServerProtocolUndefined) {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
                                              errorMessage:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
         [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
         return NO;
     }

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
@@ -20,6 +20,7 @@
 #import "VLCNetworkLoginDataSourceLogin.h"
 #import "VLCNetworkLoginDataSourceSavedLogins.h"
 #import "VLCNetworkServerLoginInformation.h"
+#import "VLC_iOS-Swift.h"
 
 
 // for protocol identifier
@@ -171,9 +172,11 @@
     self.loginInformation = login;
     NSError *error = nil;
     if (![self.savedLoginsDataSource saveLogin:login error:&error]) {
-        [[[VLCAlertView alloc] initWithTitle:error.localizedDescription
-                                    message:error.localizedFailureReason
-                          cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil) otherButtonTitles:nil] show];
+
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil) buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:error.localizedDescription errorMessage: error.localizedFailureReason viewController:self buttonsAction:buttonsAction];
     }
 
     [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
@@ -195,11 +198,15 @@
 - (BOOL)protocolSelected
 {
     if (self.protocolDataSource.protocol == VLCServerProtocolUndefined) {
-        VLCAlertView *alertView = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
-                                                              message:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
-                                                    cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                    otherButtonTitles:nil];
-        [alertView performSelectorOnMainThread:@selector(show) withObject:nil waitUntilDone:NO];
+
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
+                                             errorMessage: NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
         [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow animated:YES];
         return NO;
     }

--- a/Sources/VLC for iOS-Prefix.pch
+++ b/Sources/VLC for iOS-Prefix.pch
@@ -23,7 +23,6 @@
 #import "VLCConstants.h"
 #import "UIColor+Presets.h"
 #import "UIBarButtonItem+Theme.h"
-#import "VLCAlertView.h"
 #import "UIViewController+VLCAlert.h"
 
 #ifndef NDEBUG

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -270,14 +270,11 @@
 
 - (void)showAlert:(NSString *)title message:(NSString *)message
 {
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                          buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: okAction];
     [VLCAlertViewController alertViewManagerWithTitle:title
                                          errorMessage:message
-                                       viewController:self.delegate
-                                        buttonsAction:buttonsAction];
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
+                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                   action: ^(UIAlertAction* action){}]]];
 }
 
 - (void)calculateRemainingTime:(CGFloat)receivedDataSize expectedDownloadSize:(CGFloat)expectedDownloadSize

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -273,8 +273,7 @@
     [VLCAlertViewController alertViewManagerWithTitle:title
                                          errorMessage:message
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                   action: ^(UIAlertAction* action){}]]];
+                                        buttonsAction:nil];
 }
 
 - (void)calculateRemainingTime:(CGFloat)receivedDataSize expectedDownloadSize:(CGFloat)expectedDownloadSize

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -272,8 +272,7 @@
 {
     [VLCAlertViewController alertViewManagerWithTitle:title
                                          errorMessage:message
-                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:nil];
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController];
 }
 
 - (void)calculateRemainingTime:(CGFloat)receivedDataSize expectedDownloadSize:(CGFloat)expectedDownloadSize

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -15,6 +15,7 @@
 #import "VLCPlaybackController.h"
 #import "VLCMediaFileDiscoverer.h"
 #import <XKKeychain/XKKeychainGenericPasswordItem.h>
+#import "VLC_iOS-Swift.h"
 
 @interface VLCBoxController ()
 {
@@ -269,12 +270,14 @@
 
 - (void)showAlert:(NSString *)title message:(NSString *)message
 {
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:title
-                                                      message:message
-                                                     delegate:nil
-                                            cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                            otherButtonTitles:nil];
-    [alert show];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                          buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: okAction];
+    [VLCAlertViewController alertViewManagerWithTitle:title
+                                         errorMessage:message
+                                       viewController:self.delegate
+                                        buttonsAction:buttonsAction];
 }
 
 - (void)calculateRemainingTime:(CGFloat)receivedDataSize expectedDownloadSize:(CGFloat)expectedDownloadSize

--- a/Sources/VLCBoxTableViewController.m
+++ b/Sources/VLCBoxTableViewController.m
@@ -248,8 +248,7 @@
     } else {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
     }
 }
 

--- a/Sources/VLCBoxTableViewController.m
+++ b/Sources/VLCBoxTableViewController.m
@@ -249,8 +249,7 @@
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                         action: ^(UIAlertAction* action){}]]];;
+                                            buttonsAction:nil];
     }
 }
 

--- a/Sources/VLCBoxTableViewController.m
+++ b/Sources/VLCBoxTableViewController.m
@@ -234,12 +234,12 @@
         /* selected item is a proper file, ask the user if s/he wants to download it */
         NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
                                                                                   action: ^(UIAlertAction* action){
-                                                                                      _selectedFile = nil;
+                                                                                      self->_selectedFile = nil;
                                                                                   }],
                                                      [[VLCAlertButton alloc] initWithTitle:NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
                                                                                   action:^(UIAlertAction* action){
-                                                                                      [_boxController downloadFileToDocumentFolder:_selectedFile];
-                                                                                      _selectedFile = nil;
+                                                                                      [self->_boxController downloadFileToDocumentFolder:self->_selectedFile];
+                                                                                      self->_selectedFile = nil;
                                                                                   }]];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]

--- a/Sources/VLCBoxTableViewController.m
+++ b/Sources/VLCBoxTableViewController.m
@@ -16,6 +16,7 @@
 #import <XKKeychain/XKKeychainGenericPasswordItem.h>
 #import "UIDevice+VLC.h"
 #import "VLCPlaybackController.h"
+#import "VLC_iOS-Swift.h"
 
 #if TARGET_OS_IOS
 @interface VLCBoxTableViewController () <VLCCloudStorageTableViewCell, BoxAuthorizationViewControllerDelegate, VLCCloudStorageDelegate, NSURLConnectionDataDelegate>
@@ -231,20 +232,32 @@
 
     if (_selectedFile.size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil) message:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]] delegate:self cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil) otherButtonTitles:NSLocalizedString(@"BUTTON_DOWNLOAD", nil), nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                              buttonAction: ^(UIAlertAction* action){}];
+        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle:NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                    buttonAction:^(UIAlertAction* action){
+                                                                        [_boxController downloadFileToDocumentFolder:_selectedFile];
+                                                                        _selectedFile = nil;
+                                                                    }];
+        [buttonsAction addObject: cancelAction];
+        [buttonsAction addObject: downloadAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
     } else {
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil) message:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]] delegate:self cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil) otherButtonTitles:nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];;
     }
 }
 
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (buttonIndex == 1)
-        [_boxController downloadFileToDocumentFolder:_selectedFile];
-    _selectedFile = nil;
-}
 #endif
 
 #pragma mark - box controller delegate

--- a/Sources/VLCBoxTableViewController.m
+++ b/Sources/VLCBoxTableViewController.m
@@ -232,29 +232,25 @@
 
     if (_selectedFile.size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                              buttonAction: ^(UIAlertAction* action){}];
-        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle:NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
-                                                                    buttonAction:^(UIAlertAction* action){
-                                                                        [_boxController downloadFileToDocumentFolder:_selectedFile];
-                                                                        _selectedFile = nil;
-                                                                    }];
-        [buttonsAction addObject: cancelAction];
-        [buttonsAction addObject: downloadAction];
+        NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                  action: ^(UIAlertAction* action){
+                                                                                      _selectedFile = nil;
+                                                                                  }],
+                                                     [[VLCAlertButton alloc] initWithTitle:NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                                  action:^(UIAlertAction* action){
+                                                                                      [_boxController downloadFileToDocumentFolder:_selectedFile];
+                                                                                      _selectedFile = nil;
+                                                                                  }]];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
                                             buttonsAction:buttonsAction];
     } else {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:buttonsAction];;
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                         action: ^(UIAlertAction* action){}]]];;
     }
 }
 

--- a/Sources/VLCBugreporter.m
+++ b/Sources/VLCBugreporter.m
@@ -35,8 +35,8 @@
 
 - (void)handleBugreportRequest
 {
-    NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                              action: ^(UIAlertAction* action){}],
+    NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                              action:nil],
                                                  [[VLCAlertButton alloc] initWithTitle:NSLocalizedString(@"BUG_REPORT_BUTTON", nil)
                                                                               action: ^(UIAlertAction* action){
                                                                                   NSURL *url = [NSURL URLWithString:@"https://trac.videolan.org/vlc/newticket"];

--- a/Sources/VLCBugreporter.m
+++ b/Sources/VLCBugreporter.m
@@ -14,6 +14,8 @@
 
 #import "VLCBugreporter.h"
 
+#import "VLC_iOS-Swift.h"
+
 @implementation VLCBugreporter
 
 #pragma mark - Initialization
@@ -33,19 +35,19 @@
 
 - (void)handleBugreportRequest
 {
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"BUG_REPORT_TITLE", nil)
-                                                      message:NSLocalizedString(@"BUG_REPORT_MESSAGE", nil) delegate:self
-                                            cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                            otherButtonTitles:NSLocalizedString(@"BUG_REPORT_BUTTON", nil), nil];;
-    [alert show];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                              buttonAction: ^(UIAlertAction* action){}];
+    ButtonAction *reportAction = [[ButtonAction alloc] initWithButtonTitle:NSLocalizedString(@"BUG_REPORT_BUTTON", nil)
+                                                              buttonAction: ^(UIAlertAction* action){
+                                                                  NSURL *url = [NSURL URLWithString:@"https://trac.videolan.org/vlc/newticket"];
+                                                                  [[UIApplication sharedApplication] openURL:url];
+                                                              }];
+    [buttonsAction addObject: cancelAction];
+    [buttonsAction addObject: reportAction];
+    [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"BUG_REPORT_TITLE", nil)
+                                         errorMessage:NSLocalizedString(@"BUG_REPORT_MESSAGE", nil)
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
+                                        buttonsAction:buttonsAction];
 }
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (buttonIndex == 1) {
-        NSURL *url = [NSURL URLWithString:@"https://trac.videolan.org/vlc/newticket"];
-        [[UIApplication sharedApplication] openURL:url];
-    }
-}
-
 @end

--- a/Sources/VLCBugreporter.m
+++ b/Sources/VLCBugreporter.m
@@ -35,16 +35,14 @@
 
 - (void)handleBugreportRequest
 {
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                              buttonAction: ^(UIAlertAction* action){}];
-    ButtonAction *reportAction = [[ButtonAction alloc] initWithButtonTitle:NSLocalizedString(@"BUG_REPORT_BUTTON", nil)
-                                                              buttonAction: ^(UIAlertAction* action){
-                                                                  NSURL *url = [NSURL URLWithString:@"https://trac.videolan.org/vlc/newticket"];
-                                                                  [[UIApplication sharedApplication] openURL:url];
-                                                              }];
-    [buttonsAction addObject: cancelAction];
-    [buttonsAction addObject: reportAction];
+    NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                              action: ^(UIAlertAction* action){}],
+                                                 [[VLCAlertButton alloc] initWithTitle:NSLocalizedString(@"BUG_REPORT_BUTTON", nil)
+                                                                              action: ^(UIAlertAction* action){
+                                                                                  NSURL *url = [NSURL URLWithString:@"https://trac.videolan.org/vlc/newticket"];
+                                                                                  [[UIApplication sharedApplication] openURL:url];
+                                                                              }]
+                                                 ];
     [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"BUG_REPORT_TITLE", nil)
                                          errorMessage:NSLocalizedString(@"BUG_REPORT_MESSAGE", nil)
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController

--- a/Sources/VLCDownloadViewController.m
+++ b/Sources/VLCDownloadViewController.m
@@ -139,17 +139,19 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
     if ([self.urlField.text length] > 0) {
         NSURL *URLtoSave = [NSURL URLWithString:self.urlField.text];
         if (![URLtoSave.lastPathComponent isSupportedFormat] && ![URLtoSave.lastPathComponent.pathExtension isEqualToString:@""]) {
-            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-            ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
-            [buttonsAction addObject: cancelAction];
-            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"FILE_NOT_SUPPORTED", nil) errorMessage: [NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent] viewController:self buttonsAction:buttonsAction];
+            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"FILE_NOT_SUPPORTED", nil)
+                                                 errorMessage: [NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent]
+                                               viewController:self
+                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                             action: ^(UIAlertAction* action){}]]];
             return;
         }
         if (![URLtoSave.scheme isEqualToString:@"http"] & ![URLtoSave.scheme isEqualToString:@"https"] && ![URLtoSave.scheme isEqualToString:@"ftp"]) {
-            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-            ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
-            [buttonsAction addObject: cancelAction];
-            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil) errorMessage: [NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme] viewController:self buttonsAction:buttonsAction];
+            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
+                                                 errorMessage: [NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme]
+                                               viewController:self
+                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                             action: ^(UIAlertAction* action){}]]];
             return;
         }
 
@@ -313,10 +315,11 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
 
 - (void)downloadFailedWithErrorDescription:(NSString *)description
 {
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: cancelAction];
-    [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil) errorMessage: description viewController:self buttonsAction:buttonsAction];
+    [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
+                                         errorMessage: description
+                                       viewController:self
+                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                       action: ^(UIAlertAction* action){}]]];
 }
 
 - (void)progressUpdatedTo:(CGFloat)percentage receivedDataSize:(CGFloat)receivedDataSize  expectedDownloadSize:(CGFloat)expectedDownloadSize
@@ -389,10 +392,11 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
 {
     _FTPDownloadRequest = nil;
     [self downloadEnded];
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: cancelAction];
-    [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), request.error.errorCode] errorMessage: request.error.message viewController:self buttonsAction:buttonsAction];
+    [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), request.error.errorCode]
+                                         errorMessage: request.error.message
+                                       viewController:self
+                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                        action: ^(UIAlertAction* action){}]]];
 }
 
 #pragma mark - table view data source

--- a/Sources/VLCDownloadViewController.m
+++ b/Sources/VLCDownloadViewController.m
@@ -141,15 +141,13 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
         if (![URLtoSave.lastPathComponent isSupportedFormat] && ![URLtoSave.lastPathComponent.pathExtension isEqualToString:@""]) {
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"FILE_NOT_SUPPORTED", nil)
                                                  errorMessage:[NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent]
-                                               viewController:self
-                                                buttonsAction:nil];
+                                               viewController:self];
             return;
         }
         if (![URLtoSave.scheme isEqualToString:@"http"] & ![URLtoSave.scheme isEqualToString:@"https"] && ![URLtoSave.scheme isEqualToString:@"ftp"]) {
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
                                                  errorMessage:[NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme]
-                                               viewController:self
-                                                buttonsAction:nil];
+                                               viewController:self];
             return;
         }
 
@@ -315,8 +313,7 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
 {
     [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
                                          errorMessage:description
-                                       viewController:self
-                                        buttonsAction:nil];
+                                       viewController:self];
 }
 
 - (void)progressUpdatedTo:(CGFloat)percentage receivedDataSize:(CGFloat)receivedDataSize  expectedDownloadSize:(CGFloat)expectedDownloadSize
@@ -391,8 +388,7 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
     [self downloadEnded];
     [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), request.error.errorCode]
                                          errorMessage:request.error.message
-                                       viewController:self
-                                        buttonsAction:nil];
+                                       viewController:self];
 }
 
 #pragma mark - table view data source

--- a/Sources/VLCDownloadViewController.m
+++ b/Sources/VLCDownloadViewController.m
@@ -139,21 +139,17 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
     if ([self.urlField.text length] > 0) {
         NSURL *URLtoSave = [NSURL URLWithString:self.urlField.text];
         if (![URLtoSave.lastPathComponent isSupportedFormat] && ![URLtoSave.lastPathComponent.pathExtension isEqualToString:@""]) {
-            VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"FILE_NOT_SUPPORTED", nil)
-                                                              message:[NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent]
-                                                             delegate:self
-                                                    cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                    otherButtonTitles:nil];
-            [alert show];
+            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+            ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
+            [buttonsAction addObject: cancelAction];
+            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"FILE_NOT_SUPPORTED", nil) errorMessage: [NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent] viewController:self buttonsAction:buttonsAction];
             return;
         }
         if (![URLtoSave.scheme isEqualToString:@"http"] & ![URLtoSave.scheme isEqualToString:@"https"] && ![URLtoSave.scheme isEqualToString:@"ftp"]) {
-            VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
-                                                              message:[NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme]
-                                                             delegate:self
-                                                    cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                    otherButtonTitles:nil];
-            [alert show];
+            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+            ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
+            [buttonsAction addObject: cancelAction];
+            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil) errorMessage: [NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme] viewController:self buttonsAction:buttonsAction];
             return;
         }
 
@@ -317,12 +313,10 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
 
 - (void)downloadFailedWithErrorDescription:(NSString *)description
 {
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DOWNLOAD_FAILED", nil)
-                                                      message:description
-                                                     delegate:self
-                                            cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                            otherButtonTitles:nil];
-    [alert performSelectorOnMainThread:@selector(show) withObject:nil waitUntilDone:NO];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: cancelAction];
+    [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil) errorMessage: description viewController:self buttonsAction:buttonsAction];
 }
 
 - (void)progressUpdatedTo:(CGFloat)percentage receivedDataSize:(CGFloat)receivedDataSize  expectedDownloadSize:(CGFloat)expectedDownloadSize
@@ -395,13 +389,10 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
 {
     _FTPDownloadRequest = nil;
     [self downloadEnded];
-
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), request.error.errorCode]
-                                                       message:request.error.message
-                                                      delegate:self
-                                             cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                             otherButtonTitles:nil];
-    [alert performSelectorOnMainThread:@selector(show) withObject:nil waitUntilDone:NO];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil) buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: cancelAction];
+    [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), request.error.errorCode] errorMessage: request.error.message viewController:self buttonsAction:buttonsAction];
 }
 
 #pragma mark - table view data source

--- a/Sources/VLCDownloadViewController.m
+++ b/Sources/VLCDownloadViewController.m
@@ -140,18 +140,16 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
         NSURL *URLtoSave = [NSURL URLWithString:self.urlField.text];
         if (![URLtoSave.lastPathComponent isSupportedFormat] && ![URLtoSave.lastPathComponent.pathExtension isEqualToString:@""]) {
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"FILE_NOT_SUPPORTED", nil)
-                                                 errorMessage: [NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent]
+                                                 errorMessage:[NSString stringWithFormat:NSLocalizedString(@"FILE_NOT_SUPPORTED_LONG", nil), URLtoSave.lastPathComponent]
                                                viewController:self
-                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                                             action: ^(UIAlertAction* action){}]]];
+                                                buttonsAction:nil];
             return;
         }
         if (![URLtoSave.scheme isEqualToString:@"http"] & ![URLtoSave.scheme isEqualToString:@"https"] && ![URLtoSave.scheme isEqualToString:@"ftp"]) {
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
-                                                 errorMessage: [NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme]
+                                                 errorMessage:[NSString stringWithFormat:NSLocalizedString(@"SCHEME_NOT_SUPPORTED_LONG", nil), URLtoSave.scheme]
                                                viewController:self
-                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                                             action: ^(UIAlertAction* action){}]]];
+                                                buttonsAction:nil];
             return;
         }
 
@@ -316,10 +314,9 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
 - (void)downloadFailedWithErrorDescription:(NSString *)description
 {
     [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SCHEME_NOT_SUPPORTED", nil)
-                                         errorMessage: description
+                                         errorMessage:description
                                        viewController:self
-                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                                       action: ^(UIAlertAction* action){}]]];
+                                        buttonsAction:nil];
 }
 
 - (void)progressUpdatedTo:(CGFloat)percentage receivedDataSize:(CGFloat)receivedDataSize  expectedDownloadSize:(CGFloat)expectedDownloadSize
@@ -393,10 +390,9 @@ typedef NS_ENUM(NSUInteger, VLCDownloadScheme) {
     _FTPDownloadRequest = nil;
     [self downloadEnded];
     [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), request.error.errorCode]
-                                         errorMessage: request.error.message
+                                         errorMessage:request.error.message
                                        viewController:self
-                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                        action: ^(UIAlertAction* action){}]]];
+                                        buttonsAction:nil];
 }
 
 #pragma mark - table view data source

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -328,8 +328,7 @@
 #if TARGET_OS_IOS
     [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                          errorMessage:error.localizedDescription
-                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:nil];
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController];
 #else
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                                                    message:error.localizedDescription

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -326,14 +326,12 @@
 - (void)_handleError:(NSError *)error
 {
 #if TARGET_OS_IOS
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                              buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: cancelAction];
     [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                          errorMessage:error.localizedDescription
-                                       viewController:self.delegate
-                                        buttonsAction:buttonsAction];
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
+                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                     action: ^(UIAlertAction* action){}]
+                                                        ]];
 #else
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                                                    message:error.localizedDescription

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -17,6 +17,7 @@
 #import "VLCActivityManager.h"
 #import "VLCMediaFileDiscoverer.h"
 #import "VLCDropboxConstants.h"
+#import "VLC_iOS-Swift.h"
 
 @interface VLCDropboxController ()
 {
@@ -325,12 +326,14 @@
 - (void)_handleError:(NSError *)error
 {
 #if TARGET_OS_IOS
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
-                                                      message:error.localizedDescription
-                                                     delegate:self
-                                            cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                            otherButtonTitles:nil];
-    [alert show];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                              buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: cancelAction];
+    [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
+                                         errorMessage:error.localizedDescription
+                                       viewController:self.delegate
+                                        buttonsAction:buttonsAction];
 #else
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                                                    message:error.localizedDescription

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -329,9 +329,7 @@
     [VLCAlertViewController alertViewManagerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                          errorMessage:error.localizedDescription
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                                     action: ^(UIAlertAction* action){}]
-                                                        ]];
+                                        buttonsAction:nil];
 #else
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:NSLocalizedString(@"ERROR_NUMBER", nil), error.code]
                                                                    message:error.localizedDescription

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -188,8 +188,7 @@
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                       action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
     }
 }
 

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -19,6 +19,7 @@
 #import "VLCCloudStorageTableViewCell.h"
 #import "UIDevice+VLC.h"
 #import "VLCAppDelegate.h"
+#import "VLC_iOS-Swift.h"
 
 @interface VLCDropboxTableViewController () <VLCCloudStorageTableViewCell, VLCCloudStorageDelegate>
 {
@@ -168,28 +169,31 @@
 
     if (((DBFILESFileMetadata *)_selectedFile).size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                otherButtonTitles:NSLocalizedString(@"BUTTON_DOWNLOAD", nil), nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){
+                                                                      [_dropboxController downloadFileToDocumentFolder:_selectedFile];
+                                                                      _selectedFile = nil;
+                                                                  }];
+        [buttonsAction addObject: cancelAction];
+        [buttonsAction addObject: downloadAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
+
     } else {
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                otherButtonTitles:nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
     }
-}
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (buttonIndex == 1)
-        [_dropboxController downloadFileToDocumentFolder:_selectedFile];
-
-    _selectedFile = nil;
 }
 
 #endif

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -187,8 +187,7 @@
     } else {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
     }
 }
 

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -171,12 +171,12 @@
         /* selected item is a proper file, ask the user if s/he wants to download it */
         NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
                                                                                   action: ^(UIAlertAction* action){
-                                                                                      _selectedFile = nil;
+                                                                                      self->_selectedFile = nil;
                                                                                   }],
                                                    [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
                                                                                 action: ^(UIAlertAction* action){
-                                                                                    [_dropboxController downloadFileToDocumentFolder:_selectedFile];
-                                                                                    _selectedFile = nil;
+                                                                                    [self->_dropboxController downloadFileToDocumentFolder:self->_selectedFile];
+                                                                                    self->_selectedFile = nil;
                                                                                 }]
                                                      ];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -169,30 +169,27 @@
 
     if (((DBFILESFileMetadata *)_selectedFile).size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){
-                                                                      [_dropboxController downloadFileToDocumentFolder:_selectedFile];
-                                                                      _selectedFile = nil;
-                                                                  }];
-        [buttonsAction addObject: cancelAction];
-        [buttonsAction addObject: downloadAction];
+        NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                  action: ^(UIAlertAction* action){
+                                                                                      _selectedFile = nil;
+                                                                                  }],
+                                                   [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                                action: ^(UIAlertAction* action){
+                                                                                    [_dropboxController downloadFileToDocumentFolder:_selectedFile];
+                                                                                    _selectedFile = nil;
+                                                                                }]
+                                                     ];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
                                             buttonsAction:buttonsAction];
 
     } else {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:buttonsAction];
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                       action: ^(UIAlertAction* action){}]]];
     }
 }
 

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -16,6 +16,7 @@
 #import "NSString+SupportedMedia.h"
 #import "VLCPlaybackController.h"
 #import "VLCMediaFileDiscoverer.h"
+#import "VLC_iOS-Swift.h"
 #import <XKKeychain/XKKeychain.h>
 
 #import <AppAuth/AppAuth.h>
@@ -128,12 +129,14 @@
 
 - (void)showAlert:(NSString *)title message:(NSString *)message
 {
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle: title
-                                                      message: message
-                                                     delegate: nil
-                                            cancelButtonTitle: @"OK"
-                                            otherButtonTitles: nil];
-    [alert show];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                              buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: cancelAction];
+    [VLCAlertViewController alertViewManagerWithTitle:title
+                                         errorMessage:message
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
+                                        buttonsAction:buttonsAction];
 }
 
 #pragma mark - file management

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -129,14 +129,11 @@
 
 - (void)showAlert:(NSString *)title message:(NSString *)message
 {
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                              buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: cancelAction];
     [VLCAlertViewController alertViewManagerWithTitle:title
                                          errorMessage:message
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:buttonsAction];
+                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                   action: ^(UIAlertAction* action){}]]];
 }
 
 #pragma mark - file management

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -131,8 +131,7 @@
 {
     [VLCAlertViewController alertViewManagerWithTitle:title
                                          errorMessage:message
-                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:nil];
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController];
 }
 
 #pragma mark - file management

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -132,8 +132,7 @@
     [VLCAlertViewController alertViewManagerWithTitle:title
                                          errorMessage:message
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                   action: ^(UIAlertAction* action){}]]];
+                                        buttonsAction:nil];
 }
 
 #pragma mark - file management

--- a/Sources/VLCGoogleDriveTableViewController.m
+++ b/Sources/VLCGoogleDriveTableViewController.m
@@ -128,30 +128,26 @@
 
     if (_selectedFile.size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){
-                                                                      [_googleDriveController downloadFileToDocumentFolder:_selectedFile];
-                                                                      _selectedFile = nil;
-                                                                  }];
-
-        [buttonsAction addObject: cancelAction];
-        [buttonsAction addObject: downloadAction];
+        NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                  action: ^(UIAlertAction* action){
+                                                                                      _selectedFile = nil;
+                                                                                  }],
+                                                     [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                                  action: ^(UIAlertAction* action){
+                                                                                      [_googleDriveController downloadFileToDocumentFolder:_selectedFile];
+                                                                                      _selectedFile = nil;
+                                                                                  }]
+                                                     ];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
                                             buttonsAction:buttonsAction];
     } else {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:buttonsAction];
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                         action: ^(UIAlertAction* action){}]]];
     }
 }
 #pragma mark - login dialog

--- a/Sources/VLCGoogleDriveTableViewController.m
+++ b/Sources/VLCGoogleDriveTableViewController.m
@@ -146,8 +146,7 @@
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                         action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
     }
 }
 #pragma mark - login dialog

--- a/Sources/VLCGoogleDriveTableViewController.m
+++ b/Sources/VLCGoogleDriveTableViewController.m
@@ -17,6 +17,7 @@
 #import "VLCGoogleDriveController.h"
 #import "UIDevice+VLC.h"
 #import "VLCCloudStorageTableViewCell.h"
+#import "VLC_iOS-Swift.h"
 
 #import <AppAuth/AppAuth.h>
 #import <GTMAppAuth/GTMAppAuth.h>
@@ -127,29 +128,32 @@
 
     if (_selectedFile.size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                otherButtonTitles:NSLocalizedString(@"BUTTON_DOWNLOAD", nil), nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){
+                                                                      [_googleDriveController downloadFileToDocumentFolder:_selectedFile];
+                                                                      _selectedFile = nil;
+                                                                  }];
+
+        [buttonsAction addObject: cancelAction];
+        [buttonsAction addObject: downloadAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
     } else {
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                otherButtonTitles:nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
     }
 }
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (buttonIndex == 1)
-        [_googleDriveController downloadFileToDocumentFolder:_selectedFile];
-    _selectedFile = nil;
-}
-
 #pragma mark - login dialog
 
 - (IBAction)loginAction:(id)sender

--- a/Sources/VLCGoogleDriveTableViewController.m
+++ b/Sources/VLCGoogleDriveTableViewController.m
@@ -130,12 +130,12 @@
         /* selected item is a proper file, ask the user if s/he wants to download it */
         NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
                                                                                   action: ^(UIAlertAction* action){
-                                                                                      _selectedFile = nil;
+                                                                                      self->_selectedFile = nil;
                                                                                   }],
                                                      [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
                                                                                   action: ^(UIAlertAction* action){
-                                                                                      [_googleDriveController downloadFileToDocumentFolder:_selectedFile];
-                                                                                      _selectedFile = nil;
+                                                                                      [self->_googleDriveController downloadFileToDocumentFolder:_selectedFile];
+                                                                                      self->_selectedFile = nil;
                                                                                   }]
                                                      ];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)

--- a/Sources/VLCGoogleDriveTableViewController.m
+++ b/Sources/VLCGoogleDriveTableViewController.m
@@ -145,8 +145,7 @@
     } else {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
     }
 }
 #pragma mark - login dialog

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -728,8 +728,7 @@
                                                        NSLocalizedString(@"DISK_FULL_FORMAT", nil),
                                                        filename,
                                                        [[UIDevice currentDevice] model]]
-                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:nil];
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController];
 #else
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                                              message:[NSString stringWithFormat:

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -723,17 +723,14 @@
 - (void)notifyUserAboutEndOfFreeStorage:(NSString *)filename
 {
 #if TARGET_OS_IOS
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                              buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: okAction];
     [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                          errorMessage:[NSString stringWithFormat:
                                                        NSLocalizedString(@"DISK_FULL_FORMAT", nil),
                                                        filename,
                                                        [[UIDevice currentDevice] model]]
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:buttonsAction];
+                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                   action: ^(UIAlertAction* action){}]]];
 #else
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                                              message:[NSString stringWithFormat:

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -26,6 +26,7 @@
 #import "UIDevice+VLC.h"
 #import "VLCHTTPUploaderController.h"
 #import "VLCMetaData.h"
+#import "VLC_iOS-Swift.h"
 
 #if TARGET_OS_IOS
 #import "VLCThumbnailsCache.h"
@@ -722,15 +723,17 @@
 - (void)notifyUserAboutEndOfFreeStorage:(NSString *)filename
 {
 #if TARGET_OS_IOS
-    VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                                      message:[NSString stringWithFormat:
-                                                               NSLocalizedString(@"DISK_FULL_FORMAT", nil),
-                                                               filename,
-                                                               [[UIDevice currentDevice] model]]
-                                                     delegate:self
-                                            cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                            otherButtonTitles:nil];
-    [alert show];
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                              buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: okAction];
+    [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                         errorMessage:[NSString stringWithFormat:
+                                                       NSLocalizedString(@"DISK_FULL_FORMAT", nil),
+                                                       filename,
+                                                       [[UIDevice currentDevice] model]]
+                                       viewController:[UIApplication sharedApplication].keyWindow.rootViewController
+                                        buttonsAction:buttonsAction];
 #else
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                                              message:[NSString stringWithFormat:

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -729,8 +729,7 @@
                                                        filename,
                                                        [[UIDevice currentDevice] model]]
                                        viewController:[UIApplication sharedApplication].keyWindow.rootViewController
-                                        buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                   action: ^(UIAlertAction* action){}]]];
+                                        buttonsAction:nil];
 #else
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                                              message:[NSString stringWithFormat:

--- a/Sources/VLCHTTPFileDownloader.m
+++ b/Sources/VLCHTTPFileDownloader.m
@@ -114,8 +114,7 @@
         if (_expectedDownloadSize  > [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) { //handle too big a download
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                  errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _fileName, [[UIDevice currentDevice] model]]
-                                               viewController:self.delegate
-                                                buttonsAction:nil];
+                                               viewController:self.delegate];
             [_sessionTask cancel];
             [self _downloadEnded];
             return;

--- a/Sources/VLCHTTPFileDownloader.m
+++ b/Sources/VLCHTTPFileDownloader.m
@@ -16,6 +16,7 @@
 #import "VLCActivityManager.h"
 #import "UIDevice+VLC.h"
 #import "VLCMediaFileDiscoverer.h"
+#import "VLC_iOS-Swift.h"
 
 @interface VLCHTTPFileDownloader () <NSURLSessionDelegate>
 {
@@ -111,12 +112,14 @@
         _expectedDownloadSize = [response expectedContentLength];
         APLog(@"expected download size: %lli", _expectedDownloadSize);
         if (_expectedDownloadSize  > [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) { //handle too big a download
-            VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                                             message:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _fileName, [[UIDevice currentDevice] model]]
-                                                             delegate:self
-                                                    cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                    otherButtonTitles:nil];
-            [alert show];
+            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+            ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+            [buttonsAction addObject: okAction];
+            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                                 errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _fileName, [[UIDevice currentDevice] model]]
+                                               viewController:self.delegate
+                                                buttonsAction:buttonsAction];
             [_sessionTask cancel];
             [self _downloadEnded];
             return;

--- a/Sources/VLCHTTPFileDownloader.m
+++ b/Sources/VLCHTTPFileDownloader.m
@@ -112,14 +112,11 @@
         _expectedDownloadSize = [response expectedContentLength];
         APLog(@"expected download size: %lli", _expectedDownloadSize);
         if (_expectedDownloadSize  > [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) { //handle too big a download
-            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-            ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-            [buttonsAction addObject: okAction];
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                  errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _fileName, [[UIDevice currentDevice] model]]
                                                viewController:self.delegate
-                                                buttonsAction:buttonsAction];
+                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                             action: ^(UIAlertAction* action){}]]];
             [_sessionTask cancel];
             [self _downloadEnded];
             return;

--- a/Sources/VLCHTTPFileDownloader.m
+++ b/Sources/VLCHTTPFileDownloader.m
@@ -115,8 +115,7 @@
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                                  errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _fileName, [[UIDevice currentDevice] model]]
                                                viewController:self.delegate
-                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                             action: ^(UIAlertAction* action){}]]];
+                                                buttonsAction:nil];
             [_sessionTask cancel];
             [self _downloadEnded];
             return;

--- a/Sources/VLCOneDriveTableViewController.m
+++ b/Sources/VLCOneDriveTableViewController.m
@@ -200,12 +200,12 @@
         /* selected item is a proper file, ask the user if s/he wants to download it */
         NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
                                                                                     action: ^(UIAlertAction* action){
-                                                                                        _selectedFile = nil;
+                                                                                        self->_selectedFile = nil;
                                                                                     }],
                                                      [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
                                                                                     action: ^(UIAlertAction* action){
-                                                                                        [_oneDriveController downloadObject:_selectedFile];
-                                                                                        _selectedFile = nil;
+                                                                                        [self->_oneDriveController downloadObject:self->_selectedFile];
+                                                                                        self->_selectedFile = nil;
                                                                                     }]];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
@@ -217,7 +217,7 @@
                                            viewController:self
                                             buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
                                                                                          action: ^(UIAlertAction* action){
-                                                                                             _selectedFile = nil;
+                                                                                             self->_selectedFile = nil;
                                                                                          }]]];
     }
 }

--- a/Sources/VLCOneDriveTableViewController.m
+++ b/Sources/VLCOneDriveTableViewController.m
@@ -198,29 +198,27 @@
 
     if (_selectedFile.size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){
-                                                                      [_oneDriveController downloadObject:_selectedFile];
-                                                                      _selectedFile = nil;
-                                                                  }];
-        [buttonsAction addObject: cancelAction];
-        [buttonsAction addObject: downloadAction];
+        NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                    action: ^(UIAlertAction* action){
+                                                                                        _selectedFile = nil;
+                                                                                    }],
+                                                     [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                                    action: ^(UIAlertAction* action){
+                                                                                        [_oneDriveController downloadObject:_selectedFile];
+                                                                                        _selectedFile = nil;
+                                                                                    }]];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
                                             buttonsAction:buttonsAction];
     } else {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:buttonsAction];
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                         action: ^(UIAlertAction* action){
+                                                                                             _selectedFile = nil;
+                                                                                         }]]];
     }
 }
 #endif

--- a/Sources/VLCOneDriveTableViewController.m
+++ b/Sources/VLCOneDriveTableViewController.m
@@ -19,6 +19,7 @@
 #import "UIDevice+VLC.h"
 #import "NSString+SupportedMedia.h"
 #import "VLCConstants.h"
+#import "VLC_iOS-Swift.h"
 
 @interface VLCOneDriveTableViewController () <VLCCloudStorageDelegate>
 {
@@ -197,28 +198,30 @@
 
     if (_selectedFile.size.longLongValue < [[UIDevice currentDevice] VLCFreeDiskSpace].longLongValue) {
         /* selected item is a proper file, ask the user if s/he wants to download it */
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                otherButtonTitles:NSLocalizedString(@"BUTTON_DOWNLOAD", nil), nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        ButtonAction *downloadAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_DOWNLOAD", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){
+                                                                      [_oneDriveController downloadObject:_selectedFile];
+                                                                      _selectedFile = nil;
+                                                                  }];
+        [buttonsAction addObject: cancelAction];
+        [buttonsAction addObject: downloadAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DROPBOX_DOWNLOAD", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DROPBOX_DL_LONG", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
     } else {
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                otherButtonTitles:nil];
-        [alert show];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), _selectedFile.name, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
     }
-}
-
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (buttonIndex == 1)
-        [_oneDriveController downloadObject:_selectedFile];
-
-    _selectedFile = nil;
 }
 #endif
 

--- a/Sources/VLCOpenInActivity.m
+++ b/Sources/VLCOpenInActivity.m
@@ -88,8 +88,7 @@
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_FILES", nil)
                                              errorMessage:nil
                                            viewController:self.activityViewController
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                         action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
         [self activityDidFinish:NO];
     }
 }
@@ -129,9 +128,7 @@
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_APPLICATIONS", nil)
                                                  errorMessage:nil
                                                viewController:self.activityViewController
-                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                               action: ^(UIAlertAction* action){}]
-                                                                ]];
+                                                buttonsAction:nil];
             [self activityDidFinish:NO];
         }
     };

--- a/Sources/VLCOpenInActivity.m
+++ b/Sources/VLCOpenInActivity.m
@@ -87,8 +87,7 @@
     } else {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_FILES", nil)
                                              errorMessage:nil
-                                           viewController:self.activityViewController
-                                            buttonsAction:nil];
+                                           viewController:self.activityViewController];
         [self activityDidFinish:NO];
     }
 }
@@ -127,8 +126,7 @@
         if (!controllerWasPresentedSuccessfully) {
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_APPLICATIONS", nil)
                                                  errorMessage:nil
-                                               viewController:self.activityViewController
-                                                buttonsAction:nil];
+                                               viewController:self.activityViewController];
             [self activityDidFinish:NO];
         }
     };

--- a/Sources/VLCOpenInActivity.m
+++ b/Sources/VLCOpenInActivity.m
@@ -85,14 +85,11 @@
     } else if (count == 1) {
         [self presentDocumentInteractionControllerWithFileURL:[_fileURLs firstObject]];
     } else {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_FILES", nil)
                                              errorMessage:nil
                                            viewController:self.activityViewController
-                                            buttonsAction:buttonsAction];
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                         action: ^(UIAlertAction* action){}]]];
         [self activityDidFinish:NO];
     }
 }
@@ -129,15 +126,12 @@
         controllerWasPresentedSuccessfully = [self->_documentInteractionController presentOpenInMenuFromBarButtonItem:self.presentingBarButtonItem animated:YES];
 
         if (!controllerWasPresentedSuccessfully) {
-
-            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-            ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                      buttonAction: ^(UIAlertAction* action){}];
-            [buttonsAction addObject: cancelAction];
             [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_APPLICATIONS", nil)
                                                  errorMessage:nil
                                                viewController:self.activityViewController
-                                                buttonsAction:buttonsAction];
+                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                               action: ^(UIAlertAction* action){}]
+                                                                ]];
             [self activityDidFinish:NO];
         }
     };

--- a/Sources/VLCOpenInActivity.m
+++ b/Sources/VLCOpenInActivity.m
@@ -15,6 +15,8 @@
 
 #import <MobileCoreServices/MobileCoreServices.h>
 
+#import "VLC_iOS-Swift.h"
+
 @interface VLCOpenInActivity () <UIDocumentInteractionControllerDelegate>
 @end
 
@@ -83,13 +85,14 @@
     } else if (count == 1) {
         [self presentDocumentInteractionControllerWithFileURL:[_fileURLs firstObject]];
     } else {
-        VLCAlertView *alertView = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_FILES", nil)
-                                                              message:nil
-                                                             delegate:nil
-                                                    cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                    otherButtonTitles:nil];
-        [alertView show];
-
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_FILES", nil)
+                                             errorMessage:nil
+                                           viewController:self.activityViewController
+                                            buttonsAction:buttonsAction];
         [self activityDidFinish:NO];
     }
 }
@@ -126,13 +129,15 @@
         controllerWasPresentedSuccessfully = [self->_documentInteractionController presentOpenInMenuFromBarButtonItem:self.presentingBarButtonItem animated:YES];
 
         if (!controllerWasPresentedSuccessfully) {
-            VLCAlertView *alertView = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_APPLICATIONS", nil)
-                                                                  message:nil
-                                                                 delegate:nil
-                                                        cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                        otherButtonTitles:nil];
-            [alertView show];
 
+            NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+            ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                      buttonAction: ^(UIAlertAction* action){}];
+            [buttonsAction addObject: cancelAction];
+            [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"SHARING_ERROR_NO_APPLICATIONS", nil)
+                                                 errorMessage:nil
+                                               viewController:self.activityViewController
+                                                buttonsAction:buttonsAction];
             [self activityDidFinish:NO];
         }
     };

--- a/Sources/VLCOpenNetworkStreamViewController.m
+++ b/Sources/VLCOpenNetworkStreamViewController.m
@@ -205,8 +205,7 @@
     if ([self.urlField.text length] <= 0 || [NSURL URLWithString:self.urlField.text] == nil) {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"URL_NOT_SUPPORTED", nil)
                                              errorMessage:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
         return;
     }
     if (!self.privateToggleSwitch.on) {
@@ -422,8 +421,7 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
     } else {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
                                              errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]]
-                                           viewController:self
-                                            buttonsAction:nil];
+                                           viewController:self];
     }
 
     return fileSubtitlePath;

--- a/Sources/VLCOpenNetworkStreamViewController.m
+++ b/Sources/VLCOpenNetworkStreamViewController.m
@@ -203,16 +203,14 @@
 - (IBAction)openButtonAction:(id)sender
 {
     if ([self.urlField.text length] <= 0 || [NSURL URLWithString:self.urlField.text] == nil) {
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"URL_NOT_SUPPORTED", nil)
-                                                                                 message:nil
-                                                                          preferredStyle:UIAlertControllerStyleAlert];
-
-        UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                           style:UIAlertActionStyleCancel
-                                                         handler:nil];
-
-        [alertController addAction:okAction];
-        [self presentViewController:alertController animated:YES completion:nil];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                  buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: cancelAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"URL_NOT_SUPPORTED", nil)
+                                             errorMessage: NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
+                                           viewController:self
+                                            buttonsAction:buttonsAction];
         return;
     }
     if (!self.privateToggleSwitch.on) {
@@ -426,12 +424,10 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
         }
         [receivedSub writeToFile:fileSubtitlePath atomically:YES];
     } else {
-        VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                                          message:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]]
-                                                         delegate:self
-                                                cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                otherButtonTitles:nil];
-        [alert performSelectorOnMainThread:@selector(show) withObject:nil waitUntilDone:NO];
+        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+        ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil) buttonAction: ^(UIAlertAction* action){}];
+        [buttonsAction addObject: okAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil) errorMessage: [NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]] viewController:self buttonsAction:buttonsAction];
     }
 
     return fileSubtitlePath;

--- a/Sources/VLCOpenNetworkStreamViewController.m
+++ b/Sources/VLCOpenNetworkStreamViewController.m
@@ -203,14 +203,11 @@
 - (IBAction)openButtonAction:(id)sender
 {
     if ([self.urlField.text length] <= 0 || [NSURL URLWithString:self.urlField.text] == nil) {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                  buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: cancelAction];
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"URL_NOT_SUPPORTED", nil)
                                              errorMessage: NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
                                            viewController:self
-                                            buttonsAction:buttonsAction];
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                       action: ^(UIAlertAction* action){}]]];
         return;
     }
     if (!self.privateToggleSwitch.on) {
@@ -424,10 +421,11 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
         }
         [receivedSub writeToFile:fileSubtitlePath atomically:YES];
     } else {
-        NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-        ButtonAction *okAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil) buttonAction: ^(UIAlertAction* action){}];
-        [buttonsAction addObject: okAction];
-        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil) errorMessage: [NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]] viewController:self buttonsAction:buttonsAction];
+        [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
+                                             errorMessage: [NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]]
+                                           viewController:self
+                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                     action: ^(UIAlertAction* action){}]]];
     }
 
     return fileSubtitlePath;

--- a/Sources/VLCOpenNetworkStreamViewController.m
+++ b/Sources/VLCOpenNetworkStreamViewController.m
@@ -204,10 +204,9 @@
 {
     if ([self.urlField.text length] <= 0 || [NSURL URLWithString:self.urlField.text] == nil) {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"URL_NOT_SUPPORTED", nil)
-                                             errorMessage: NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
+                                             errorMessage:NSLocalizedString(@"PROTOCOL_NOT_SELECTED", nil)
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                       action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
         return;
     }
     if (!self.privateToggleSwitch.on) {
@@ -422,10 +421,9 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
         [receivedSub writeToFile:fileSubtitlePath atomically:YES];
     } else {
         [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"DISK_FULL", nil)
-                                             errorMessage: [NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]]
+                                             errorMessage:[NSString stringWithFormat:NSLocalizedString(@"DISK_FULL_FORMAT", nil), fileName, [[UIDevice currentDevice] model]]
                                            viewController:self
-                                            buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                     action: ^(UIAlertAction* action){}]]];
+                                            buttonsAction:nil];
     }
 
     return fileSubtitlePath;

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -23,6 +23,7 @@
 #import "VLCConstants.h"
 #import "VLCRemoteControlService.h"
 #import "VLCMetadata.h"
+#import "VLC_iOS-Swift.h"
 
 NSString *const VLCPlaybackControllerPlaybackDidStart = @"VLCPlaybackControllerPlaybackDidStart";
 NSString *const VLCPlaybackControllerPlaybackDidPause = @"VLCPlaybackControllerPlaybackDidPause";
@@ -1172,17 +1173,19 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
             if (continuePlayback == 1) {
                 [self setPlaybackPosition:lastPosition];
             } else if (continuePlayback == 0) {
-                VLCAlertView *alert = [[VLCAlertView alloc] initWithTitle:NSLocalizedString(@"CONTINUE_PLAYBACK", nil)
-                                                                  message:[NSString stringWithFormat:NSLocalizedString(@"CONTINUE_PLAYBACK_LONG", nil), item.title]
-                                                                 delegate:self
-                                                        cancelButtonTitle:NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                        otherButtonTitles:NSLocalizedString(@"BUTTON_CONTINUE", nil), nil];
-                alert.completion = ^(BOOL cancelled, NSInteger buttonIndex) {
-                    if (!cancelled) {
-                        [self setPlaybackPosition:lastPosition];
-                    }
-                };
-                [alert show];
+                NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+                ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                          buttonAction: ^(UIAlertAction* action){}];
+                ButtonAction *continueAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CONTINUE", nil)
+                                                                            buttonAction: ^(UIAlertAction* action){
+                                                                                [self setPlaybackPosition:lastPosition];
+                                                                            }];
+                [buttonsAction addObject: cancelAction];
+                [buttonsAction addObject: continueAction];
+                [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"CONTINUE_PLAYBACK", nil)
+                                                     errorMessage:[NSString stringWithFormat:NSLocalizedString(@"CONTINUE_PLAYBACK_LONG", nil), item.title]
+                                                   viewController:self
+                                                    buttonsAction:buttonsAction];
             }
         }
     }

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1173,18 +1173,16 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
             if (continuePlayback == 1) {
                 [self setPlaybackPosition:lastPosition];
             } else if (continuePlayback == 0) {
-                NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-                ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                          buttonAction: ^(UIAlertAction* action){}];
-                ButtonAction *continueAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_CONTINUE", nil)
-                                                                            buttonAction: ^(UIAlertAction* action){
-                                                                                [self setPlaybackPosition:lastPosition];
-                                                                            }];
-                [buttonsAction addObject: cancelAction];
-                [buttonsAction addObject: continueAction];
+                NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
+                                                                                                                       action: ^(UIAlertAction* action){}],
+                                                             [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CONTINUE", nil)
+                                                                                                                         action: ^(UIAlertAction* action){
+                                                                                                                             [self setPlaybackPosition:lastPosition];
+                                                                                                                         }]
+                                                             ];
                 [VLCAlertViewController alertViewManagerWithTitle:NSLocalizedString(@"CONTINUE_PLAYBACK", nil)
                                                      errorMessage:[NSString stringWithFormat:NSLocalizedString(@"CONTINUE_PLAYBACK_LONG", nil), item.title]
-                                                   viewController:self
+                                                   viewController:self.delegate
                                                     buttonsAction:buttonsAction];
             }
         }

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1174,7 +1174,7 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
                 [self setPlaybackPosition:lastPosition];
             } else if (continuePlayback == 0) {
                 NSArray<VLCAlertButton *> *buttonsAction = @[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CANCEL", nil)
-                                                                                                                       action: ^(UIAlertAction* action){}],
+                                                                                                                       action: nil],
                                                              [[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_CONTINUE", nil)
                                                                                                                          action: ^(UIAlertAction* action){
                                                                                                                              [self setPlaybackPosition:lastPosition];

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -199,8 +199,7 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
             [VLCAlertViewController alertViewManagerWithTitle:failedString
                                                  errorMessage:nil
                                                viewController:self
-                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                                                           action: ^(UIAlertAction* action){}]]];
+                                                buttonsAction:nil];
             break;
     }
 #else

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -15,7 +15,7 @@
 #import "VLCMiniPlaybackView.h"
 #import "VLCPlaybackNavigationController.h"
 #import "VLCPlaybackController+MediaLibrary.h"
-
+#import "VLC_iOS-Swift.h"
 #if TARGET_OS_IOS
 #import "VLC_iOS-Swift.h"
 #import "VLCMovieViewController.h"
@@ -188,6 +188,10 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
 {
     NSString *failedString = NSLocalizedString(@"PLAYBACK_FAILED", nil);
 #if TARGET_OS_IOS
+    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
+    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                              buttonAction: ^(UIAlertAction* action){}];
+    [buttonsAction addObject: cancelAction];
     switch (self.displayMode) {
         case VLCPlayerDisplayControllerDisplayModeFullscreen:
             if ([self.movieViewController respondsToSelector:@selector(showStatusMessage:forPlaybackController:)]) {
@@ -196,12 +200,10 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
             break;
         case VLCPlayerDisplayControllerDisplayModeMiniplayer:
         default:
-
-            [[[VLCAlertView alloc] initWithTitle:failedString
-                                         message:nil
-                                        delegate:nil
-                               cancelButtonTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                               otherButtonTitles:nil] show];
+            [VLCAlertViewController alertViewManagerWithTitle:failedString
+                                                 errorMessage:nil
+                                               viewController:self
+                                                buttonsAction:buttonsAction];
             break;
     }
 #else

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -198,8 +198,7 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
         default:
             [VLCAlertViewController alertViewManagerWithTitle:failedString
                                                  errorMessage:nil
-                                               viewController:self
-                                                buttonsAction:nil];
+                                               viewController:self];
             break;
     }
 #else

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -188,10 +188,6 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
 {
     NSString *failedString = NSLocalizedString(@"PLAYBACK_FAILED", nil);
 #if TARGET_OS_IOS
-    NSMutableArray<ButtonAction *> *buttonsAction = [[NSMutableArray alloc] init];
-    ButtonAction *cancelAction = [[ButtonAction alloc] initWithButtonTitle: NSLocalizedString(@"BUTTON_OK", nil)
-                                                              buttonAction: ^(UIAlertAction* action){}];
-    [buttonsAction addObject: cancelAction];
     switch (self.displayMode) {
         case VLCPlayerDisplayControllerDisplayModeFullscreen:
             if ([self.movieViewController respondsToSelector:@selector(showStatusMessage:forPlaybackController:)]) {
@@ -203,7 +199,8 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
             [VLCAlertViewController alertViewManagerWithTitle:failedString
                                                  errorMessage:nil
                                                viewController:self
-                                                buttonsAction:buttonsAction];
+                                                buttonsAction:@[[[VLCAlertButton alloc] initWithTitle: NSLocalizedString(@"BUTTON_OK", nil)
+                                                                                           action: ^(UIAlertAction* action){}]]];
             break;
     }
 #else

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1745A7B520A471C4004FBEA7 /* VLCAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1745A7B420A471C4004FBEA7 /* VLCAlertViewController.swift */; };
 		1D72DC00CD4A06E8789BD8F7 /* libPods-VLC-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FE1DEC7096649D63A308D86C /* libPods-VLC-tvOS.a */; };
 		26F1BFD01A770408001DF30C /* libMediaVLC.xml in Resources */ = {isa = PBXBuildFile; fileRef = 26F1BFCF1A770408001DF30C /* libMediaVLC.xml */; };
 		29125E5617492219003F03E5 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 29125E5417492219003F03E5 /* index.html */; };
@@ -131,7 +132,6 @@
 		7D4408591BDA8DCA0080FB42 /* VLCBoxController.m in Sources */ = {isa = PBXBuildFile; fileRef = 41CD69591A29D72600E60BCE /* VLCBoxController.m */; };
 		7D4625881A5614A1001A80B4 /* VLCEqualizerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D4625871A5614A1001A80B4 /* VLCEqualizerView.m */; };
 		7D4DF2181B55209200739326 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D4DF2171B55209200739326 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		7D50903218F41C7900180139 /* VLCAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D50903118F41C7900180139 /* VLCAlertView.m */; };
 		7D51B3B01BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D51B3AE1BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.m */; };
 		7D51B3B11BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D51B3AF1BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.xib */; };
 		7D5278E21BD7E06E00D0CA0E /* VLCDropboxController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D3784AA183A9906009EE944 /* VLCDropboxController.m */; };
@@ -466,6 +466,7 @@
 /* Begin PBXFileReference section */
 		018698905AC809BE4496D84D /* Pods-vlc-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-vlc-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-vlc-ios/Pods-vlc-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		090F2933E962C424E9A80ABB /* Pods-VLC-iOS-no-watch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOS-no-watch.release.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOS-no-watch/Pods-VLC-iOS-no-watch.release.xcconfig"; sourceTree = "<group>"; };
+		1745A7B420A471C4004FBEA7 /* VLCAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCAlertViewController.swift; sourceTree = "<group>"; };
 		1C7724AABC40B96010E01F65 /* Pods-VLC-iOS-no-watch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOS-no-watch.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOS-no-watch/Pods-VLC-iOS-no-watch.debug.xcconfig"; sourceTree = "<group>"; };
 		260624EB5BF9F1FBE58BF816 /* libPods-VLC for iOSUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VLC for iOSUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		268BDA7D1B4FE1E200D622DD /* backArrow_black.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = backArrow_black.png; path = ImportedSources/OneDrive/src/LiveSDK/Library/Internal/Resources/backArrow_black.png; sourceTree = SOURCE_ROOT; };
@@ -761,8 +762,6 @@
 		7D4BE733175F82CA00861CD4 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; lineEnding = 0; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.simpleColoring; };
 		7D4C484417ACF982008D228B /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7D4DF2171B55209200739326 /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
-		7D50903018F41C7900180139 /* VLCAlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VLCAlertView.h; path = Sources/VLCAlertView.h; sourceTree = SOURCE_ROOT; };
-		7D50903118F41C7900180139 /* VLCAlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VLCAlertView.m; path = Sources/VLCAlertView.m; sourceTree = SOURCE_ROOT; };
 		7D51B3AD1BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLCPlaybackInfoMediaInfoTVViewController.h; sourceTree = "<group>"; };
 		7D51B3AE1BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VLCPlaybackInfoMediaInfoTVViewController.m; sourceTree = "<group>"; };
 		7D51B3AF1BF0EEF4005AF4D5 /* VLCPlaybackInfoMediaInfoTVViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = VLCPlaybackInfoMediaInfoTVViewController.xib; path = "Playback/Playback Info/VLCPlaybackInfoMediaInfoTVViewController.xib"; sourceTree = "<group>"; };
@@ -1437,14 +1436,13 @@
 				7D3784BB183A9938009EE944 /* VLCSlider.m */,
 				7D3784BC183A9938009EE944 /* VLCStatusLabel.h */,
 				7D3784BD183A9938009EE944 /* VLCStatusLabel.m */,
-				7D50903018F41C7900180139 /* VLCAlertView.h */,
-				7D50903118F41C7900180139 /* VLCAlertView.m */,
 				7D9CB9DA1A4C55EF00BB74B4 /* VLCPlaybackNavigationController.h */,
 				7D9CB9DB1A4C55EF00BB74B4 /* VLCPlaybackNavigationController.m */,
 				DDC10BE21AEE8EA700890DC3 /* VLCTimeNavigationTitleView.h */,
 				DDC10BE31AEE8EA700890DC3 /* VLCTimeNavigationTitleView.m */,
 				DD1CB0581BBAC549006EDDE6 /* VLCVolumeView.h */,
 				DD1CB0591BBAC549006EDDE6 /* VLCVolumeView.m */,
+				1745A7B420A471C4004FBEA7 /* VLCAlertViewController.swift */,
 				8DD651B0208F62B70052EE68 /* VLCActionSheet */,
 			);
 			name = "UI Elements";
@@ -3200,7 +3198,6 @@
 				7D4625881A5614A1001A80B4 /* VLCEqualizerView.m in Sources */,
 				7DF9352F1958AB0600E60FD4 /* UIColor+Presets.m in Sources */,
 				41F5C0781F41ED55005EB9CB /* VLCLibrarySearchDisplayDataSource.m in Sources */,
-				7D50903218F41C7900180139 /* VLCAlertView.m in Sources */,
 				7DBBF182183AB3B80009A339 /* VLCAppDelegate.m in Sources */,
 				418B145020179CB9000447AA /* LayoutAnchorContainer.swift in Sources */,
 				7D3784C0183A9938009EE944 /* VLCLinearProgressIndicator.m in Sources */,
@@ -3228,6 +3225,7 @@
 				7D30F3C3183AB24C00FFC021 /* VLCHTTPFileDownloader.m in Sources */,
 				41273A3C1A955C4100A2EF77 /* VLCMigrationViewController.m in Sources */,
 				7D30F3C4183AB24C00FFC021 /* VLCHTTPUploaderController.m in Sources */,
+				1745A7B520A471C4004FBEA7 /* VLCAlertViewController.swift in Sources */,
 				7D30F3C7183AB26F00FFC021 /* VLCOpenNetworkStreamViewController.m in Sources */,
 				41E6BECD207E64E900E158BA /* RemoteNetworkCell.swift in Sources */,
 				DD1CB05A1BBAC549006EDDE6 /* VLCVolumeView.m in Sources */,

--- a/VLCAlertViewController.swift
+++ b/VLCAlertViewController.swift
@@ -29,8 +29,6 @@ typealias AlertAction = (UIAlertAction) -> Void
 
    @objc class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController,
                                        buttonsAction: [ButtonAction]) {
-    print(buttonsAction[0].buttonTitle)
-    print(buttonsAction[0].buttonAction)
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
         alert.show(viewController, sender: Any?.self)
         for buttonAction in buttonsAction {

--- a/VLCAlertViewController.swift
+++ b/VLCAlertViewController.swift
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * VLCAlertControllerExtension.swift
+ * VLCAlertViewController.swift
  * VLC for iOS
  *****************************************************************************
  * Copyright (c) 2018 VideoLAN. All rights reserved.
@@ -15,44 +15,42 @@ import UIKit
 typealias AlertAction = (UIAlertAction) -> Void
 
 
-@objcMembers class ButtonAction: NSObject {
-    let buttonTitle: String
-    var buttonAction: AlertAction
-    init(buttonTitle: String, buttonAction: @escaping AlertAction) {
-        self.buttonTitle = buttonTitle
-        self.buttonAction = buttonAction
+@objcMembers class VLCAlertButton: NSObject {
+    let title: String
+    var action: AlertAction
+    init(title: String, action: @escaping AlertAction) {
+        self.title = title
+        self.action = action
     }
-
 }
 
-@objc class VLCAlertViewController: UIAlertController {
+@objcMembers class VLCAlertViewController: UIAlertController {
 
-   @objc class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController,
-                                       buttonsAction: [ButtonAction]) {
+    class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController,
+                                      buttonsAction: [VLCAlertButton]) {
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
-        alert.show(viewController, sender: Any?.self)
         for buttonAction in buttonsAction {
-            let action = UIAlertAction(title: buttonAction.buttonTitle, style: UIAlertActionStyle.default, handler: buttonAction.buttonAction)
+            let action = UIAlertAction(title: buttonAction.title, style: UIAlertActionStyle.default, handler: buttonAction.action)
             alert.addAction(action)
         }
+        alert.show(viewController, sender: Any?.self)
         viewController.present(alert, animated: true, completion: nil)
     }
 
-   @objc class func alertManagerWithTextField(title: String, errorMessage: String? = nil, viewController: UIViewController,
-                                         buttonsAction: [ButtonAction], textFieldText: String? = nil,
-                                         textFieldPlaceholder: String? = nil) {
+    class func alertManagerWithTextField(title: String, errorMessage: String? = nil, viewController: UIViewController,
+                                               buttonsAction: [VLCAlertButton],
+                                               textFieldText: String? = nil,
+                                               textFieldPlaceholder: String? = nil) {
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
-        alert.show(viewController, sender: Any?.self)
         alert.addTextField(configurationHandler: { textField in
             textField.placeholder = textFieldPlaceholder
             textField.text = textFieldText
-            textField.isSecureTextEntry = false
-            textField.textAlignment = .left
         })
         for buttonAction in buttonsAction {
-            let action = UIAlertAction(title: buttonAction.buttonTitle, style: UIAlertActionStyle.default, handler: buttonAction.buttonAction)
+            let action = UIAlertAction(title: buttonAction.title, style: UIAlertActionStyle.default, handler: buttonAction.action)
             alert.addAction(action)
         }
+        alert.show(viewController, sender: Any?.self)
         viewController.present(alert, animated: true, completion: nil)
     }
 }

--- a/VLCAlertViewController.swift
+++ b/VLCAlertViewController.swift
@@ -14,11 +14,10 @@ import UIKit
 
 typealias AlertAction = (UIAlertAction) -> Void
 
-
 @objcMembers class VLCAlertButton: NSObject {
     let title: String
-    var action: AlertAction
-    init(title: String, action: @escaping AlertAction) {
+    var action: AlertAction?
+    init(title: String, action: AlertAction? = nil) {
         self.title = title
         self.action = action
     }
@@ -27,10 +26,15 @@ typealias AlertAction = (UIAlertAction) -> Void
 @objcMembers class VLCAlertViewController: UIAlertController {
 
     class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController,
-                                      buttonsAction: [VLCAlertButton]) {
+                                      buttonsAction: [VLCAlertButton]?) {
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
-        for buttonAction in buttonsAction {
-            let action = UIAlertAction(title: buttonAction.title, style: UIAlertActionStyle.default, handler: buttonAction.action)
+        if let buttonsAction = buttonsAction {
+            for buttonAction in buttonsAction {
+                let action = UIAlertAction(title: buttonAction.title, style: UIAlertActionStyle.default, handler: buttonAction.action)
+                alert.addAction(action)
+            }
+        } else {
+            let action = UIAlertAction(title: NSLocalizedString("BUTTON_OK", comment:""), style: UIAlertActionStyle.default, handler: nil)
             alert.addAction(action)
         }
         alert.show(viewController, sender: Any?.self)

--- a/VLCAlertViewController.swift
+++ b/VLCAlertViewController.swift
@@ -1,0 +1,60 @@
+/*****************************************************************************
+ * VLCAlertControllerExtension.swift
+ * VLC for iOS
+ *****************************************************************************
+ * Copyright (c) 2018 VideoLAN. All rights reserved.
+ * $Id$
+ *
+ * Authors: Quentin Richard <Quentinr75@gmail.com>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
+
+import UIKit
+
+typealias AlertAction = (UIAlertAction) -> Void
+
+
+@objcMembers class ButtonAction: NSObject {
+    let buttonTitle: String
+    var buttonAction: AlertAction
+    init(buttonTitle: String, buttonAction: @escaping AlertAction) {
+        self.buttonTitle = buttonTitle
+        self.buttonAction = buttonAction
+    }
+
+}
+
+@objc class VLCAlertViewController: UIAlertController {
+
+   @objc class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController,
+                                       buttonsAction: [ButtonAction]) {
+    print(buttonsAction[0].buttonTitle)
+    print(buttonsAction[0].buttonAction)
+        let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
+        alert.show(viewController, sender: Any?.self)
+        for buttonAction in buttonsAction {
+            let action = UIAlertAction(title: buttonAction.buttonTitle, style: UIAlertActionStyle.default, handler: buttonAction.buttonAction)
+            alert.addAction(action)
+        }
+        viewController.present(alert, animated: true, completion: nil)
+    }
+
+   @objc class func alertManagerWithTextField(title: String, errorMessage: String? = nil, viewController: UIViewController,
+                                         buttonsAction: [ButtonAction], textFieldText: String? = nil,
+                                         textFieldPlaceholder: String? = nil) {
+        let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
+        alert.show(viewController, sender: Any?.self)
+        alert.addTextField(configurationHandler: { textField in
+            textField.placeholder = textFieldPlaceholder
+            textField.text = textFieldText
+            textField.isSecureTextEntry = false
+            textField.textAlignment = .left
+        })
+        for buttonAction in buttonsAction {
+            let action = UIAlertAction(title: buttonAction.buttonTitle, style: UIAlertActionStyle.default, handler: buttonAction.buttonAction)
+            alert.addAction(action)
+        }
+        viewController.present(alert, animated: true, completion: nil)
+    }
+}

--- a/VLCAlertViewController.swift
+++ b/VLCAlertViewController.swift
@@ -25,8 +25,11 @@ typealias AlertAction = (UIAlertAction) -> Void
 
 @objcMembers class VLCAlertViewController: UIAlertController {
 
-    class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController,
-                                      buttonsAction: [VLCAlertButton]?) {
+    class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController) {
+        VLCAlertViewController.alertViewManager(title: title, errorMessage: errorMessage, viewController: viewController, buttonsAction: nil)
+    }
+
+    class func alertViewManager(title: String, errorMessage: String? = nil, viewController: UIViewController, buttonsAction: [VLCAlertButton]?) {
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
         if let buttonsAction = buttonsAction {
             for buttonAction in buttonsAction {
@@ -41,10 +44,11 @@ typealias AlertAction = (UIAlertAction) -> Void
         viewController.present(alert, animated: true, completion: nil)
     }
 
-    class func alertManagerWithTextField(title: String, errorMessage: String? = nil, viewController: UIViewController,
-                                               buttonsAction: [VLCAlertButton],
-                                               textFieldText: String? = nil,
-                                               textFieldPlaceholder: String? = nil) {
+    class func alertManagerWithTextField(title: String, errorMessage: String? = nil,
+                                         viewController: UIViewController,
+                                         buttonsAction: [VLCAlertButton],
+                                         textFieldText: String? = nil,
+                                         textFieldPlaceholder: String? = nil) {
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
         alert.addTextField(configurationHandler: { textField in
             textField.placeholder = textFieldPlaceholder


### PR DESCRIPTION
Please try to resolved the given following issue related with MobileVLCKit in xcode 9.2 , swift4.0 .
1.libvlc_MetadataCancel(creating player instance with private library as options were given)
2.playlist_preparser_Cancel
3.vlc_custom_create
Issue occur when try to play MobileVLCKit more than one time.
<img width="268" alt="screen shot 2018-06-13 at 10 51 19 am" src="https://user-images.githubusercontent.com/20200124/41390187-35a05d3e-6fb2-11e8-8907-b338f17b6129.png">
