### PR TITLE
CI: Cache installed pods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,16 @@ jobs:
           paths:
             - .bundle
       - restore_cache:
-          key: v1-pods-{{ checksum "Podfile.lock" }}
+          key: v2-pods-{{ checksum "Podfile" }}
       - run:
           name: Install CocoaPods
           command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-            pod install
+            [ -d "Pods" ] || (curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; pod install)
       - save_cache:
-          key: v1-pods-{{ checksum "Podfile.lock" }}
+          key: v2-pods-{{ checksum "Podfile" }}
           paths:
             - Pods
+            - Podfile.lock
       - run: bundle exec fastlane ci
       - store_artifacts:
           path: /Users/distiller/Library/Logs/gym


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description

According to CircleCI, 
> If you are using CocoaPods, then we recommend that you check your Pods directory into source control. This will ensure that you have a deterministic, reproducible build.
https://circleci.com/docs/2.0/testing-ios/#using-cocoapods

But `Pods` is 2.6 GB while the entire project is 2.8 GB 😅
So this PR tries to cache the pods in CircleCI instead of the repo with contents of `Podfile` as the key to the cache.