### PR TITLE
VLCHTTPUploaderController: change standard port to 8080 to avoid Chro…

### DIFF
--- a/Sources/VLCHTTPUploaderController.m
+++ b/Sources/VLCHTTPUploaderController.m
@@ -102,17 +102,11 @@
 - (NSString *)httpStatus
 {
     if (_httpServer.isRunning) {
-        if (_httpServer.listeningPort != 80) {
-            return [NSString stringWithFormat:@"http://%@:%i\nhttp://%@:%i",
-                    [self hostname],
-                    _httpServer.listeningPort,
-                    [self currentIPAddress],
-                    _httpServer.listeningPort];
-        } else {
-            return [NSString stringWithFormat:@"http://%@\nhttp://%@",
-                    [self hostname],
-                    [self currentIPAddress]];
-        }
+        return [NSString stringWithFormat:@"http://%@:%i\nhttp://%@:%i",
+                [self hostname],
+                _httpServer.listeningPort,
+                [self currentIPAddress],
+                _httpServer.listeningPort];
     } else {
         return NSLocalizedString(@"HTTP_UPLOAD_SERVER_OFF", nil);
     }
@@ -216,7 +210,7 @@
     APLog(@"Setting document root: %@", docRoot);
 
     [_httpServer setDocumentRoot:docRoot];
-    [_httpServer setPort:80];
+    [_httpServer setPort:8080];
 
     [_httpServer setConnectionClass:[VLCHTTPConnection class]];
 


### PR DESCRIPTION
…mecast conflicts

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This means we will always have to display the port in the UI. Shall I remove the default case now? And is 8080 okay as port? 