### PR TITLE
VLCMovieViewController: Correctly display Playing Externally view

### DIFF
--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -1680,7 +1680,8 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
 
 - (void)showOnDisplay:(UIView *)view
 {
-    BOOL displayExternally = view != _movieView;
+    // if we don't have a renderer we're mirroring and don't want to show the dialog
+    BOOL displayExternally = _vpc.renderer && view != _movieView;
     [_playingExternalView shouldDisplay:displayExternally];
     [_playingExternalView updateUIWithRendererItem:_vpc.renderer];
     _vpc.videoOutputView = view;
@@ -1703,9 +1704,11 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
 {
     // Create a renderer button for VLCMovieViewController
     _rendererButton = [VLCRendererDiscovererManager.sharedInstance setupRendererButton];
-    [VLCRendererDiscovererManager.sharedInstance addSelectionHandlerWithSelectionHandler:^(VLCRendererItem * item) {
+    [VLCRendererDiscovererManager.sharedInstance addSelectionHandler:^(VLCRendererItem * item) {
         if (item) {
             [self showOnDisplay:_playingExternalView.displayView];
+        } else {
+            [self removedCurrentRendererItem:_vpc.renderer];
         }
     }];
 }

--- a/Sources/VLCRendererDiscovererManager.swift
+++ b/Sources/VLCRendererDiscovererManager.swift
@@ -115,7 +115,7 @@ class VLCRendererDiscovererManager: NSObject {
         }
     }
 
-    @objc func addSelectionHandler(selectionHandler: ((_ rendererItem: VLCRendererItem?) -> Void)?) {
+    @objc func addSelectionHandler(_ selectionHandler: ((_ rendererItem: VLCRendererItem?) -> Void)?) {
         actionSheet.setAction { [weak self] (item) in
             if let rendererItem = item as? VLCRendererItem {
                 //if we select the same renderer we want to disconnect


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
 When the renderer is disconnected we want to hide the playing Externally view
 When we mirror the screen we don't want to show it either so we just check if we have a renderer

I haven't found a better way to detect if we're mirroring or not so I use if we have a renderer right now, which is not ideal. I'm also not sure if there are other cases where we display on an external screen but this fixes it for the two reported bugs