### PR TITLE
Modally present about view

### DIFF
--- a/Resources/Base.lproj/Localizable.strings
+++ b/Resources/Base.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 "CONTINUE_PLAYBACK" = "Continue playback?";
 "CONTINUE_PLAYBACK_LONG" = "Would you like to continue playback of \"%@\" where you left off?";
 
+"BUTTON_ABOUT" = "About";
 "BUTTON_ALL" = "Select All";
 "BUTTON_BACK" = "Back";
 "BUTTON_EDIT" = "Edit";

--- a/Resources/Settings.bundle/Root.inApp.plist
+++ b/Resources/Settings.bundle/Root.inApp.plist
@@ -4,20 +4,6 @@
 <dict>
 	<key>PreferenceSpecifiers</key>
 	<array>
-        <dict>
-            <key>Type</key>
-            <string>PSGroupSpecifier</string>
-            <key>Title</key>
-            <string>SETTINGS_ABOUT_TITLE</string>
-        </dict>
-        <dict>
-            <key>Key</key>
-            <string>about</string>
-            <key>Title</key>
-            <string>ABOUT_APP_IOS</string>
-            <key>Type</key>
-            <string>IASKButtonSpecifier</string>
-        </dict>
 		<dict>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 "CONTINUE_PLAYBACK_LONG" = "Would you like to continue playback of \"%@\" where you left off?";
 
 "BUTTON_ALL" = "Select All";
+"BUTTON_ABOUT" = "About";
 "BUTTON_BACK" = "Back";
 "BUTTON_EDIT" = "Edit";
 "BUTTON_DONE" = "Done";

--- a/Sources/VLCAboutViewController.m
+++ b/Sources/VLCAboutViewController.m
@@ -45,14 +45,27 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-
+    if (@available(iOS 11.0, *)) {
+        self.navigationController.navigationBar.prefersLargeTitles = NO;
+    }
+    
     self.navigationItem.titleView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"title"]];
-
+    [self.navigationItem.titleView setTintColor:PresentationTheme.current.colors.navigationbarTextColor];
+    
     UIBarButtonItem *contributeButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"BUTTON_CONTRIBUTE", nil) style:UIBarButtonItemStylePlain target:self action:@selector(openContributePage:)];
-    contributeButton.tintColor = [UIColor whiteColor];
-
-    self.navigationItem.rightBarButtonItem = contributeButton;
+    contributeButton.accessibilityIdentifier = VLCAccessibilityIdentifier.contribute;
+    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"BUTTON_DONE", nil) style:UIBarButtonItemStyleDone target:self action:@selector(dismiss)];
+    doneButton.accessibilityIdentifier = VLCAccessibilityIdentifier.done;
+    
+    self.navigationItem.leftBarButtonItem = contributeButton;
+    self.navigationItem.rightBarButtonItem = doneButton;
+    
     [self loadWebContent];
+}
+
+- (void)dismiss
+{
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)loadWebContent
@@ -111,6 +124,11 @@
 - (IBAction)openContributePage:(id)sender
 {
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.videolan.org/contribute.html"]];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return PresentationTheme.current.colors.statusBarStyle;
 }
 
 @end

--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -35,10 +35,16 @@
 
 - (void)viewDidLoad
 {
+    [super viewDidLoad];
+
     self.modalPresentationStyle = UIModalPresentationFormSheet;
     self.delegate = self;
     self.showDoneButton = NO;
     self.showCreditsFooter = NO;
+    
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"BUTTON_ABOUT", nil) style:UIBarButtonItemStylePlain target:self action:@selector(showAbout)];
+    self.navigationItem.leftBarButtonItem.accessibilityIdentifier = VLCAccessibilityIdentifier.about;
+    
     [self themeDidChange];
 }
 
@@ -123,12 +129,11 @@
     }
 }
 
-#pragma mark - IASKSettings delegate
-
-- (void)settingsViewController:(IASKAppSettingsViewController*)sender buttonTappedForSpecifier:(IASKSpecifier*)specifier
+- (void)showAbout
 {
     VLCAboutViewController *aboutVC = [[VLCAboutViewController alloc] init];
-    [self.navigationController pushViewController:aboutVC animated:YES];
+    UINavigationController *modalNavigationController = [[UINavigationController alloc] initWithRootViewController:aboutVC];
+    [self presentViewController:modalNavigationController animated:YES completion:nil];
 }
 
 #pragma mark - PAPasscode delegate
@@ -145,14 +150,10 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    IASKSpecifier *specifier  = [self.settingsReader specifierForIndexPath:indexPath];
     UITableViewCell *cell = [super tableView:tableView cellForRowAtIndexPath:indexPath];
     cell.backgroundColor = PresentationTheme.current.colors.settingsCellBackground;
     cell.textLabel.textColor = PresentationTheme.current.colors.cellTextColor;
     cell.detailTextLabel.textColor = PresentationTheme.current.colors.cellDetailTextColor;
-    if ([specifier.key isEqualToString:@"about"]) {
-        cell.accessibilityIdentifier = VLCAccessibilityIdentifier.about;
-    }
     return cell;
 }
 

--- a/VLC-iOS-UITests/Helpers/VLCAccessibilityIdentifier.swift
+++ b/VLC-iOS-UITests/Helpers/VLCAccessibilityIdentifier.swift
@@ -19,6 +19,8 @@ import Foundation
     static let cloud = "cloud"
     static let stream = "stream"
     static let downloads = "downloads"
+    @objc static let done = "done"
+    @objc static let contribute = "contribute"
     @objc static let about = "about"
     @objc static let playPause = "playPause"
 }

--- a/VLC-iOS-UITests/VLCTestMenu.swift
+++ b/VLC-iOS-UITests/VLCTestMenu.swift
@@ -66,7 +66,8 @@ class VLCTestMenu: XCTestCase {
 
     func testNavigationToAbout() {
         helper.tapTabBarItem(VLCAccessibilityIdentifier.settings)
-        app.cells[VLCAccessibilityIdentifier.about].tap()
-        XCTAssertNotNil(app.navigationBars[VLCAccessibilityIdentifier.about])
+        app.navigationBars.buttons[VLCAccessibilityIdentifier.about].tap()
+        XCTAssertNotNil(app.navigationBars.buttons[VLCAccessibilityIdentifier.done])
+        XCTAssertNotNil(app.navigationBars.buttons[VLCAccessibilityIdentifier.contribute])
     }
 }

--- a/vlc-ios/Images.xcassets/Library View/title.imageset/Contents.json
+++ b/vlc-ios/Images.xcassets/Library View/title.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "title.png"
+      "filename" : "title.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "title@2x.png"
+      "filename" : "title@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "title@3x.png"
+      "filename" : "title@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

About view in settings tab is now displayed **modally** instead of being pushed.

![simulator screen shot - iphone x - 2018-06-27 at 14 57 59](https://user-images.githubusercontent.com/5487597/41955394-dfd16f24-7a1a-11e8-9b12-03ee310b7ee3.png)
![simulator screen shot - iphone x - 2018-06-27 at 14 57 55](https://user-images.githubusercontent.com/5487597/41955395-dfff4610-7a1a-11e8-8b7e-d7b951589243.png)

