### PR TITLE
VLCMovieViewController: fix displaying on external screen via HDMI

### DIFF
--- a/SharedSources/VLCPlayingExternallyView.swift
+++ b/SharedSources/VLCPlayingExternallyView.swift
@@ -21,9 +21,8 @@ class VLCPlayingExternallyView: UIView {
     }
     var externalWindow: UIWindow?
 
-    @objc func shouldDisplay(_ show: Bool) {
+    @objc func shouldDisplay(_ show: Bool, movieView: UIView) {
         self.isHidden = !show
-        externalWindow?.isHidden = !show
         if show {
             guard let screen = UIScreen.screens.count > 1 ? UIScreen.screens[1] : nil else {
                 return
@@ -34,11 +33,14 @@ class VLCPlayingExternallyView: UIView {
                 return
             }
             externalWindow.rootViewController = VLCExternalDisplayController()
+            externalWindow.rootViewController?.view.addSubview(movieView)
             externalWindow.screen = screen
             externalWindow.rootViewController?.view.frame = externalWindow.bounds
+            movieView.frame = externalWindow.bounds
         } else {
             externalWindow = nil
         }
+        externalWindow?.isHidden = !show
     }
 
     override func awakeFromNib() {

--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -1673,11 +1673,15 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
 - (void)showOnDisplay:(UIView *)view
 {
     // if we don't have a renderer we're mirroring and don't want to show the dialog
-    BOOL displayExternally = _vpc.renderer && view != _movieView;
-    [_playingExternalView shouldDisplay:displayExternally];
+    BOOL displayExternally = view != _movieView;
+    [_playingExternalView shouldDisplay:displayExternally movieView:_movieView];
     [_playingExternalView updateUIWithRendererItem:_vpc.renderer];
-    _vpc.videoOutputView = view;
     _artworkImageView.hidden = displayExternally;
+    if (!displayExternally && _movieView.superview != self.view) {
+        [self.view addSubview:_movieView];
+        [self.view sendSubviewToBack:_movieView];
+        _movieView.frame = self.view.frame;
+    }
 }
 
 - (void)handleExternalScreenDidConnect:(NSNotification *)notification


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

 When we refactored we didn't pass the movieView to the external screen when displaying externally
This worked well for chromecast and mirroring but sadly not for attaching an external screen via HDMI

Still need to test this with mirroring and chromecast