### PR TITLE
Fastlane: version: Strip bundle version

### DIFF
--- a/fastlane/helpers/version.rb
+++ b/fastlane/helpers/version.rb
@@ -8,6 +8,6 @@ end
 
 def increment_build_number_in_plist(plistPath)
   buildNumber = `xcrun /usr/libexec/PlistBuddy -c "Print CFBundleVersion" "#{plistPath}"`
-  `/usr/libexec/PlistBuddy -c "Set :CFBundleVersion #{buildNumber.next}" "#{plistPath}"`
+  `/usr/libexec/PlistBuddy -c "Set :CFBundleVersion #{buildNumber.next.strip()}" "#{plistPath}"`
 end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This removes newline at the end of the bundle version.
Therefore removes the extra space we have in the About page.
