### PR TITLE
Fix Settings view (closes #268)

### DIFF
--- a/Sources/VLCSectionTableHeaderView.swift
+++ b/Sources/VLCSectionTableHeaderView.swift
@@ -15,6 +15,21 @@ import Foundation
 class VLCSectionTableHeaderView: UITableViewHeaderFooterView {
 
     let separator = UIView()
+    
+    @objc let label: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = PresentationTheme.current.font.tableHeaderFont
+        return label
+    }()
+    
+    let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.spacing = 8
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
@@ -28,26 +43,23 @@ class VLCSectionTableHeaderView: UITableViewHeaderFooterView {
     }
 
     func setupUI() {
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(separator)
-
+        stackView.addArrangedSubview(separator)
+        stackView.addArrangedSubview(label)
+        contentView.addSubview(stackView)
+        
         NSLayoutConstraint.activate([
-            separator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            separator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            separator.heightAnchor.constraint(equalToConstant: 1),
-            separator.topAnchor.constraint(equalTo: contentView.topAnchor)
-            ])
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -9),
+            
+            separator.heightAnchor.constraint(equalToConstant: 1)
+        ])
     }
 
     @objc func updateTheme() {
         contentView.backgroundColor = PresentationTheme.current.colors.background
         separator.backgroundColor = PresentationTheme.current.colors.separatorColor
-        textLabel?.textColor = PresentationTheme.current.colors.cellTextColor
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        textLabel?.font = PresentationTheme.current.font.tableHeaderFont
-        textLabel?.textColor = PresentationTheme.current.colors.cellTextColor
+        label.textColor = PresentationTheme.current.colors.cellTextColor
     }
 }

--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -18,7 +18,6 @@
 #import <LocalAuthentication/LocalAuthentication.h>
 #import "VLC_iOS-Swift.h"
 
-CGFloat const SETTINGS_HEADER_HEIGHT = 64.;
 NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderViewIdentifier";
 
 @interface VLCSettingsController ()<PAPasscodeViewControllerDelegate>
@@ -59,16 +58,17 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
     self.navigationItem.leftBarButtonItem.accessibilityIdentifier = VLCAccessibilityIdentifier.about;
 
     self.neverShowPrivacySettings = YES;
-    self.tableView.estimatedRowHeight = 100;
-    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
+    self.tableView.estimatedRowHeight = 100;
+    self.tableView.sectionHeaderHeight = UITableViewAutomaticDimension;
+    self.tableView.estimatedSectionHeaderHeight = 64;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     [self.tableView registerClass:[VLCSectionTableHeaderView class] forHeaderFooterViewReuseIdentifier:kVLCSectionTableHeaderViewIdentifier];
     [self themeDidChange];
 }
 
 - (void)themeDidChange
 {
-
     self.view.backgroundColor = PresentationTheme.current.colors.background;
     [self setNeedsStatusBarAppearanceUpdate];
 }
@@ -194,18 +194,13 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
 
 #pragma mark - InAppSettings customization
 
-- (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView *)tableView heightForHeaderForSection:(NSInteger)section
-{
-    return section == 0. ? 0. : SETTINGS_HEADER_HEIGHT;
-}
-
 - (UIView *)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView *)tableView viewForHeaderForSection:(NSInteger)section
 {
     if (section == 0) {
         return nil;
     }
     VLCSectionTableHeaderView *header = [tableView dequeueReusableHeaderFooterViewWithIdentifier:kVLCSectionTableHeaderViewIdentifier];
-    header.textLabel.text = [self.settingsReader titleForSection:section];
+    header.label.text = [self.settingsReader titleForSection:section];
     return header;
 }
 

--- a/Sources/VLCSettingsTableViewCell.swift
+++ b/Sources/VLCSettingsTableViewCell.swift
@@ -46,6 +46,7 @@ class VLCSettingsTableViewCell: UITableViewCell {
 
      @objc func configure(specifier: IASKSpecifier, settingsValue: Any?) {
         textLabel?.text = specifier.title()
+        textLabel?.numberOfLines = 0
         detailTextLabel?.text = specifier.subtitle()
 
         switch specifier.type() {


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description

Issue reference https://code.videolan.org/videolan/vlc-ios/issues/268.

From looking at https://developer.apple.com/documentation/uikit/uitableviewheaderfooterview/1624912-textlabel, it seems as if using the default `textLabel` to customize the header view may be a bad idea when also adding a separator (subview).

> Accessing the value in this property causes the view to create a default label for displaying a detail text string. If you are managing the content of the view yourself by adding subviews to the contentView property, you should not access this property.