### PR TITLE
Move VLCMediaFileDiscovererDelegate to VLCMediaLibraryManager

### DIFF
--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -35,7 +35,7 @@
 
 #define BETA_DISTRIBUTION 1
 
-@interface VLCAppDelegate () <VLCMediaFileDiscovererDelegate>
+@interface VLCAppDelegate ()
 {
     BOOL _isRunningMigration;
     BOOL _isComingFromHandoff;
@@ -112,12 +112,6 @@
         BOOL spotlightEnabled = ![VLCKeychainCoordinator passcodeLockEnabled];
         [[MLMediaLibrary sharedMediaLibrary] setSpotlightIndexingEnabled:spotlightEnabled];
         [[MLMediaLibrary sharedMediaLibrary] applicationWillStart];
-
-        VLCMediaFileDiscoverer *discoverer = [VLCMediaFileDiscoverer sharedInstance];
-        NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-        discoverer.directoryPath = [searchPaths firstObject];
-        [discoverer addObserver:self];
-        [discoverer startDiscovering];
     };
 
     NSError *error = nil;
@@ -281,36 +275,6 @@ didFailToContinueUserActivityWithType:(NSString *)userActivityType
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler
 {
     //TODO: shortcutItem should be implemented
-}
-
-#pragma mark - media discovering
-
-- (void)mediaFileAdded:(NSString *)fileName loading:(BOOL)isLoading
-{
-    if (!isLoading) {
-        MLMediaLibrary *sharedLibrary = [MLMediaLibrary sharedMediaLibrary];
-        [sharedLibrary addFilePaths:@[fileName]];
-
-        /* exclude media files from backup (QA1719) */
-        NSURL *excludeURL = [NSURL fileURLWithPath:fileName];
-        [excludeURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
-
-        // TODO Should we update media db after adding new files?
-        [sharedLibrary updateMediaDatabase];
-        // TODO: update the VideoViewController
-    }
-}
-
-- (void)mediaFileDeleted:(NSString *)name
-{
-    [[MLMediaLibrary sharedMediaLibrary] updateMediaDatabase];
-   // TODO: update the VideoViewController
-}
-
-- (void)mediaFilesFoundRequiringAdditionToStorageBackend:(NSArray<NSString *> *)foundFiles
-{
-    [[MLMediaLibrary sharedMediaLibrary] addFilePaths:foundFiles];
-  // TODO: update the VideoViewController
 }
 
 #pragma mark - pass code validation

--- a/Sources/VLCMediaFileDiscoverer.h
+++ b/Sources/VLCMediaFileDiscoverer.h
@@ -14,10 +14,8 @@
 
 @protocol VLCMediaFileDiscovererDelegate <NSObject>
 
-@required
-- (void)mediaFilesFoundRequiringAdditionToStorageBackend:(NSArray <NSString *> *)foundFiles;
-
 @optional
+- (void)mediaFilesFoundRequiringAdditionToStorageBackend:(NSArray <NSString *> *)foundFiles;
 // loading is equal to YES first time when file is discovered
 - (void)mediaFileAdded:(NSString *)filePath loading:(BOOL)isLoading;
 

--- a/VLC-iOS-Bridging-Header.h
+++ b/VLC-iOS-Bridging-Header.h
@@ -25,3 +25,4 @@
 #import "IASKSettingsReader.h"
 #import "IASKSwitch.h"
 #import "VLCHTTPUploaderController.h"
+#import "VLCMediaFileDiscoverer.h"


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://gfrithub.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This allows monitoring of changes in the Documents files from external
apps.

Additionally changes `mediaFilesFoundRequiringAdditionToStorageBackend`
to optional since the new medialibrary doesn't need it.

