### PR TITLE
Re-enable thumbnails(closes #293)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
   - upnpx (1.4.0)
   - VLC-LiveSDK (5.7.0x)
   - VLC-WhiteRaccoon (1.0.0)
-  - VLCMediaLibraryKit (0.0.5):
+  - VLCMediaLibraryKit (0.0.6):
     - MobileVLCKit
   - XKKeychain (1.0.1)
   - xmlrpc (2.3.4):
@@ -169,7 +169,7 @@ SPEC CHECKSUMS:
   upnpx: c695b99229e08154d23abe5c252cb64f1600f35d
   VLC-LiveSDK: c9566a9edde968f969138f84cfd40b540a109b3f
   VLC-WhiteRaccoon: 1e7e59b0568959135a89d09c416d1e11a5d9a986
-  VLCMediaLibraryKit: 0cf4f6a31571a76d6b8b6f50efe0e99486bf6b65
+  VLCMediaLibraryKit: 326ae57af5c1943cde52cf7de37f4af63655eca4
   XKKeychain: 852ef663c56a7194c73d3c68e8d9d4f07b121d4f
   xmlrpc: 109bb21d15ed6d108b2c1ac5973a6a223a50f5f4
 

--- a/SharedSources/VLCMediaLibraryManager.swift
+++ b/SharedSources/VLCMediaLibraryManager.swift
@@ -227,8 +227,7 @@ extension VLCMediaLibraryManager: VLCMediaLibraryDelegate {
         let audio = media.filter {( $0.type() == .audio )}
 
         // thumbnails only for videos
-        // FIXME: Endless loop of MediaAdded C++ side need fixing, disabling thumbnails
-        // requestThumbnail(for: videos)
+        requestThumbnail(for: videos)
 
         for observer in observers {
             observer.value.observer?.medialibrary?(self, didAddVideos: videos)


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Re-enables thumbnails when adding a new media.
The issue was fixed by the medialibrary changes.
