### PR TITLE
VLCMovieViewController: adjust activityIndicator behavior

### DIFF
--- a/Resources/VLCMovieViewController~iphone.xib
+++ b/Resources/VLCMovieViewController~iphone.xib
@@ -97,10 +97,10 @@
                     <color key="shadowColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                 </label>
                 <activityIndicatorView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" style="whiteLarge" id="vR5-i9-KEJ">
-                    <rect key="frame" x="169" y="373" width="37" height="37"/>
+                    <rect key="frame" x="170" y="316" width="37" height="37"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                 </activityIndicatorView>
-                <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="108" userLabel="Playing Externally View" customClass="VLCPlayingExternallyView" customModule="VLC_iOS" customModuleProvider="target">
+                <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" id="108" userLabel="Playing Externally View" customClass="VLCPlayingExternallyView" customModule="VLC" customModuleProvider="target">
                     <rect key="frame" x="28" y="178" width="320" height="257"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <subviews>

--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -77,6 +77,7 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
     BOOL _playbackWillClose;
     BOOL _isTapSeeking;
     VLCMovieJumpState _previousJumpState;
+    VLCMediaPlayerState _previousPlayerStateWasPlaying;
 
     UIPinchGestureRecognizer *_pinchRecognizer;
     VLCPanType _currentPanType;
@@ -814,21 +815,15 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
     [self setControlsHidden:!_controlsHidden animated:YES];
 }
 
-- (void)updateActivityIndicatorForState:(VLCMediaPlayerState)state {
-    UIActivityIndicatorView *indicator = self.activityIndicator;
-    switch (state) {
-        case VLCMediaPlayerStateBuffering:
-            if (!indicator.isAnimating) {
-                self.activityIndicator.alpha = 1.0;
-                [self.activityIndicator startAnimating];
-            }
-            break;
-        default:
-            if (indicator.isAnimating) {
-                [self.activityIndicator stopAnimating];
-                self.activityIndicator.alpha = 0.0;
-            }
-            break;
+- (void)updateActivityIndicatorForState:(VLCMediaPlayerState)state
+{
+    if (state == VLCMediaPlayerStatePlaying || state == VLCMediaPlayerStatePaused) {
+        _previousPlayerStateWasPlaying = state == VLCMediaPlayerStatePlaying;
+    }
+    BOOL shouldAnimate = state == VLCMediaPlayerStateBuffering && _previousPlayerStateWasPlaying;
+    if (self.activityIndicator.isAnimating != shouldAnimate) {
+        self.activityIndicator.alpha = shouldAnimate ? 1.0 : 0.0;
+        shouldAnimate ? [self.activityIndicator startAnimating] : [self.activityIndicator stopAnimating];
     }
 }
 


### PR DESCRIPTION
* position indicator in the middle of the movieViewController
* simplify state code and only show the indicator for buffering when we were in playing mode before
since we never get an event that we're done with buffering (closes #306)

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
