### PR TITLE
Remove Userwarnings: These warnings have no effect

### DIFF
--- a/Sources/VLCBoxConstants.h
+++ b/Sources/VLCBoxConstants.h
@@ -11,7 +11,6 @@
  *****************************************************************************/
 
 #define kVLCBoxClientID @"nrjwriavk0mf8j6bhra56tyn58d5i7ci"
-#warning Box app secret missing, login will fail
 #define kVLCBoxClientSecret @""
 #define kVLCBoxService @"kVLCBoxService"
 #define kVLCBoxAccount @"kVLCBoxAccount"

--- a/Sources/VLCDropboxConstants.h
+++ b/Sources/VLCDropboxConstants.h
@@ -11,5 +11,4 @@
  *****************************************************************************/
 
 #define kVLCDropboxAppKey @"a60fc6qj9zdg7bw"
-#warning Dropbox app secret missing, login will fail
 #define kVLCDropboxPrivateKey @""

--- a/Sources/VLCGoogleDriveConstants.h
+++ b/Sources/VLCGoogleDriveConstants.h
@@ -10,15 +10,8 @@
  * Refer to the COPYING file of the official project for license.
  *****************************************************************************/
 
-//TODO: Add ClientID
-//ClientID formating: @"xyz.apps.googleusercontent.com"
 #define kVLCGoogleDriveClientID @""
 #define kKeychainItemName @"vlc-ios"
-//TODO: Add RedirectURI
-//RedirectURI formating: @"com.googleusercontent.apps.xyz:/oauthredirect"
 #define kVLCGoogleRedirectURI @""
-#warning Google Drive app secret missing, login will fail
 #define kVLCGoogleDriveClientSecret @""
-//#define kVLCGoogleDriveAppKey @"a60fc6qj9zdg7bw"
-#warning Google Drive app private key missing, login will fail
 #define kVLCGoogleDrivePrivateKey @""


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
In development everyone will always work without the credentials and these warnings have therefore no value. If we want to ensure that we are not able to build without the credentials we could add some kind of assertion that fails if we build for production only when the keys are not set 