### PR TITLE
VLCLibraryViewController: Make reordering possible only in a folder

### DIFF
--- a/Sources/VLCLibraryViewController.m
+++ b/Sources/VLCLibraryViewController.m
@@ -574,17 +574,11 @@ static NSString *kUsingTableViewToShowData = @"UsingTableViewToShowData";
 
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (@available(iOS 11.0, *)) {
-        return true;
-    }
     return _inFolder;
 }
 
 - (BOOL)collectionView:(UICollectionView *)collectionView canMoveItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (@available(iOS 11.0, *)) {
-        return true;
-    }
     return _inFolder;
 }
 


### PR DESCRIPTION

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
closes [#313](https://code.videolan.org/videolan/vlc-ios/issues/313)

Tested this change on an iPad as well for the drag and drop, this doesn't seem to affect it.
I may have missed some DnD cases.
