### PR TITLE
MediaCategoryViewController: setFullscreenmode to true for everything…

### DIFF
--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -266,6 +266,7 @@ extension VLCMediaCategoryViewController {
     }
 
     func play(media: VLCMLMedia) {
+        VLCPlaybackController.sharedInstance().fullscreenSessionRequested = media.subtype() != .albumTrack
         VLCPlaybackController.sharedInstance().play(media)
     }
 }


### PR DESCRIPTION
… but albumtracks

(closes #292)

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
