### PR TITLE
AppDelegate: Change viewController hierachy to fix wrong frame of min…

### DIFF
--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -18,29 +18,37 @@ class Services: NSObject {
 
 @objc class AppCoordinator: NSObject {
     private var childCoordinators: [NSObject] = []
-    private var tabBarController: UITabBarController
+    private var viewController: UIViewController
     private var playerController: VLCPlayerDisplayController
+    private var tabBarController: UITabBarController
     private var services = Services()
 
-    @objc init(tabBarController: UITabBarController) {
-        self.tabBarController = tabBarController
+    @objc init(viewController: UIViewController) {
+        self.viewController = viewController
         self.playerController = VLCPlayerDisplayController(services: services)
+        self.tabBarController = UITabBarController()
         super.init()
-        setupPlayerController()
+        setupChildViewControllers()
 
         // Init the HTTP Server and clean its cache
         // FIXME: VLCHTTPUploaderController should perhaps be a service?
         VLCHTTPUploaderController.sharedInstance().cleanCache()
     }
 
-    private func setupPlayerController() {
-        tabBarController.addChildViewController(playerController)
-        tabBarController.view.addSubview(playerController.view)
+    private func setupChildViewControllers() {
+        viewController.addChildViewController(tabBarController)
+        viewController.view.addSubview(tabBarController.view)
+        tabBarController.view.frame = viewController.view.frame
+        tabBarController.didMove(toParentViewController: viewController)
+
+        viewController.addChildViewController(playerController)
+        viewController.view.addSubview(playerController.view)
         playerController.view.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: tabBarController.tabBar.frame.size.height, right: 0)
-        playerController.didMove(toParentViewController: tabBarController)
+        playerController.didMove(toParentViewController: viewController)
     }
 
     @objc func start() {
+
         let tabbarCoordinator = VLCTabBarCoordinator(tabBarController: tabBarController, services: services)
         childCoordinators.append(tabbarCoordinator)
     }

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -41,7 +41,7 @@
     BOOL _isComingFromHandoff;
     VLCKeychainCoordinator *_keychainCoordinator;
     AppCoordinator *appCoordinator;
-    UITabBarController *rootViewController;
+    UIViewController *rootViewController;
 }
 
 @end
@@ -98,13 +98,13 @@
     [VLCApperanceManager setupAppearanceWithTheme:PresentationTheme.current];
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    rootViewController = [UITabBarController new];
+    rootViewController = [UIViewController new];
     self.window.rootViewController = rootViewController;
     [self.window makeKeyAndVisible];
     // enable crash preventer
     void (^setupBlock)(void) = ^{
         void (^setupLibraryBlock)(void) = ^{
-            self->appCoordinator = [[AppCoordinator alloc] initWithTabBarController:self->rootViewController];
+            self->appCoordinator = [[AppCoordinator alloc] initWithViewController:self->rootViewController];
             [self->appCoordinator start];
         };
         [self validatePasscodeIfNeededWithCompletion:setupLibraryBlock];

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -69,6 +69,14 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
     self.view = [[VLCUntouchableView alloc] initWithFrame:self.view.frame];
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        self.view.frame = CGRectMake(0, 0, size.width, size.height);
+    } completion:nil];
+}
+
 #pragma mark - properties
 
 - (VLCPlayerDisplayControllerDisplayMode)displayMode


### PR DESCRIPTION
…iplayerView

When you add a childViewConroller to a UITabbarcontroller it will keep them in the viewControllers.
by setting the viewControllers on the tabbarcontroller later we removed the childViewController which led to that Controller
not getting any updates like willTransitionToSize. Simply appending the other viewcontrollers would show the player as additional tab
We now have plain UiViewController with tabbarController and PlayerController as ChildViewControllers to fix this layout issue

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
 
I still need to figure out how to animate the transition alongside the screen rotation but this brings us a step further