### PR TITLE
Fix thumbnails being regenerated every time

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
   - upnpx (1.4.0)
   - VLC-LiveSDK (5.7.0x)
   - VLC-WhiteRaccoon (1.0.0)
-  - VLCMediaLibraryKit (0.0.6):
+  - VLCMediaLibraryKit (0.0.7):
     - MobileVLCKit
   - XKKeychain (1.0.1)
   - xmlrpc (2.3.4):
@@ -169,7 +169,7 @@ SPEC CHECKSUMS:
   upnpx: c695b99229e08154d23abe5c252cb64f1600f35d
   VLC-LiveSDK: c9566a9edde968f969138f84cfd40b540a109b3f
   VLC-WhiteRaccoon: 1e7e59b0568959135a89d09c416d1e11a5d9a986
-  VLCMediaLibraryKit: 326ae57af5c1943cde52cf7de37f4af63655eca4
+  VLCMediaLibraryKit: 59939a20c85be0f4a1c3769ed089f4de3666d4cf
   XKKeychain: 852ef663c56a7194c73d3c68e8d9d4f07b121d4f
   xmlrpc: 109bb21d15ed6d108b2c1ac5973a6a223a50f5f4
 

--- a/SharedSources/VLCMediaLibraryManager.swift
+++ b/SharedSources/VLCMediaLibraryManager.swift
@@ -199,10 +199,7 @@ extension VLCMediaLibraryManager {
 extension VLCMediaLibraryManager {
     func requestThumbnail(for media: [VLCMLMedia]) {
         media.forEach() {
-                // FIXME: Remind Chouquette! In the medialibrary thumbnails uses absolute paths. Workaround:
-                //         - Regenerate path is a thumbnail is detected
-                //         - Request a new thumbnail
-                // if $0.isThumbnailGenerated() { return }
+            guard !$0.isThumbnailGenerated() else { return }
 
             if !medialib.requestThumbnail(for: $0) {
                 assertionFailure("VLCMediaLibraryManager: Failed to generate thumbnail for: \($0.identifier())")


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Thumbnail issue has been fixed on VLCMediaLibraryKit 0.0.7.