### PR TITLE
Fix chapter descriptions on tvOS

### DIFF
--- a/Apple-TV/Playback/Playback Info/VLCPlaybackInfoChaptersTVViewController.m
+++ b/Apple-TV/Playback/Playback Info/VLCPlaybackInfoChaptersTVViewController.m
@@ -135,7 +135,7 @@
     trackCell.selectionMarkerVisible = isSelected;
 
     VLCPlaybackController *vpc = [VLCPlaybackController sharedInstance];
-    NSDictionary *description = [vpc chapterDescriptionsDictAtIndex:[vpc indexOfCurrentTitle]];
+    NSDictionary *description = [vpc chapterDescriptionsDictAtIndex:row];
 
     NSString *chapter = description[VLCChapterDescriptionName];
     if (chapter == nil)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
A tvOS bug exists where all chapters show the name of the first chapter, rather than the names of each chapter. This is because the player's current title's index, which has nothing to do with the chapter object being processed here, is used to lookup in the chapter descriptions array. Using the current chapter's index instead results in a valid lookup and working chapter titles on my development tvOS device.

Note that the fastlane test above does not exercise this controller, and so while the tests passed, I feel guilty checking that box without declaring the caveat. Duly noted.

```
[13:03:33]: ▸ Test Succeeded
+--------------------+----+
|      Test Results       |
+--------------------+----+
| Number of tests    | 13 |
| Number of failures | 0  |
+--------------------+----+
```