### PR TITLE
Layout the subframe so that it's shown on first visit

### DIFF
--- a/Apple-TV/Playback/Playback Info/VLCPlaybackInfoTVAnimators.m
+++ b/Apple-TV/Playback/Playback Info/VLCPlaybackInfoTVAnimators.m
@@ -98,6 +98,7 @@
         toFrame = smallFrame;
         fromFrame = largeFrame;
         [container addSubview:target.view];
+        [target.view layoutIfNeeded];
     } else if ([source isKindOfClass:[VLCPlaybackInfoTVViewController class]]) {
         infoVC = (VLCPlaybackInfoTVViewController*) source;
         infoVC.dimmingView.alpha = 1.0;


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
On tvOS, there's a bug where the list of chapters isn't shown when the info pane is first opened. Switching to another tab of the pane and then back to the (default, first) Chapters tab displays the subview correctly. Calling layoutIfNeeded when binding the subview to the info controller seems to ensure that it's ready to be displayed on the first visit.

Note that the fastlane tests don't seem to test tvOS, but it does pass them, and this change _is_ effective on my local tvOS device — however I am not well-versed in the intricacies of layoutIfNeeded, so please use your best judgement here.