### PR TITLE
Add four .intValue highlighted by static analyzer

### DIFF
--- a/SharedSources/Clouds/VLCRemoteBrowsingTVCell+CloudStorage.m
+++ b/SharedSources/Clouds/VLCRemoteBrowsingTVCell+CloudStorage.m
@@ -59,7 +59,7 @@
             self.thumbnailImage = [UIImage imageNamed:@"folder"];
         } else {
             self.isDirectory = NO;
-            self.subtitle = (boxFile.size > 0) ? [NSByteCountFormatter stringFromByteCount:[boxFile.size longLongValue] countStyle:NSByteCountFormatterCountStyleFile]: @"";
+            self.subtitle = (boxFile.size.intValue > 0) ? [NSByteCountFormatter stringFromByteCount:[boxFile.size longLongValue] countStyle:NSByteCountFormatterCountStyleFile]: @"";
             self.thumbnailImage = [UIImage imageNamed:@"blank"];
         }
         self.title = boxFile.name;
@@ -85,13 +85,13 @@
                 }
             }
 
-            if (oneDriveFile.size > 0) {
+            if (oneDriveFile.size.intValue > 0) {
                 [subtitle appendString:[NSByteCountFormatter stringFromByteCount:[oneDriveFile.size longLongValue] countStyle:NSByteCountFormatterCountStyleFile]];
-                if (oneDriveFile.duration > 0) {
+                if (oneDriveFile.duration.intValue > 0) {
                     VLCTime *time = [VLCTime timeWithNumber:oneDriveFile.duration];
                     [subtitle appendFormat:@" — %@", [time verboseStringValue]];
                 }
-            } else if (oneDriveFile.duration > 0) {
+            } else if (oneDriveFile.duration.intValue > 0) {
                 VLCTime *time = [VLCTime timeWithNumber:oneDriveFile.duration];
                 [subtitle appendString:[time verboseStringValue]];
             }


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
Xcode identified what it believes are four cases of integer comparison without the necessary .intValue method for converting the NSNumber to an integer for the comparison to succeed.

Each case does appear to be correctly identified, so this adds four instances of .intValue matching similar cases elsewhere in the codebase.

I unfortunately do not have access to the two services this patch affects — Box and OneDrive — so I can only perform fastlane and "it runs on the TV" tests, which all pass.

```
[17:28:30]: ▸ 	 Executed 12 tests, with 0 failures (0 unexpected) in 95.890 (95.897) seconds
[17:28:43]: ▸ Done linting! Found 0 violations, 0 serious in 58 files.
```