### PR TITLE
Keep showing the video view when pausing a video in the mini player

### DIFF
--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -44,6 +44,7 @@ class Services: NSObject {
         viewController.addChildViewController(playerController)
         viewController.view.addSubview(playerController.view)
         playerController.view.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: tabBarController.tabBar.frame.size.height, right: 0)
+        playerController.realBottomAnchor = tabBarController.tabBar.topAnchor
         playerController.didMove(toParentViewController: viewController)
     }
 

--- a/Sources/MediaViewControllers/MediaViewController.swift
+++ b/Sources/MediaViewControllers/MediaViewController.swift
@@ -77,7 +77,7 @@ class VLCMediaViewController: VLCPagingViewController<VLCLabelCell> {
         sortOptionsAlertController.addAction(sortbyDateAction)
         sortOptionsAlertController.addAction(sortBySizeAction)
         sortOptionsAlertController.addAction(cancelAction)
-        sortOptionsAlertController.view.tintColor = UIColor.vlcOrangeTint()
+        sortOptionsAlertController.view.tintColor = .vlcOrangeTint
         sortOptionsAlertController.popoverPresentationController?.sourceView = self.view
         present(sortOptionsAlertController, animated: true)
     }

--- a/Sources/UIColor+Presets.h
+++ b/Sources/UIColor+Presets.h
@@ -14,13 +14,13 @@
 
 @interface UIColor (Presets)
 
-+ (UIColor *)VLCDarkBackgroundColor;
-+ (UIColor *)VLCTransparentDarkBackgroundColor;
-+ (UIColor *)VLCLightTextColor;
-+ (UIColor *)VLCDarkFadedTextColor;
-+ (UIColor *)VLCDarkTextColor;
-+ (UIColor *)VLCDarkTextShadowColor;
-+ (UIColor *)VLCOrangeTintColor;
-+ (UIColor *)VLCMenuBackgroundColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCDarkBackgroundColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCTransparentDarkBackgroundColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCLightTextColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCDarkFadedTextColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCDarkTextColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCDarkTextShadowColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCOrangeTintColor;
+@property (nonatomic, strong, readonly, nonnull, class) UIColor *VLCMenuBackgroundColor;
 
 @end

--- a/Sources/UIColor+Presets.m
+++ b/Sources/UIColor+Presets.m
@@ -14,41 +14,41 @@
 
 @implementation UIColor (Presets)
 
-+ (UIColor *)VLCDarkBackgroundColor
++ (nonnull UIColor *)VLCDarkBackgroundColor
 {
     return [UIColor colorWithWhite:.122 alpha:1.];
 }
 
-+ (UIColor *)VLCTransparentDarkBackgroundColor
++ (nonnull UIColor *)VLCTransparentDarkBackgroundColor
 {
     return [UIColor colorWithWhite:.122 alpha:0.75];
 }
 
-+ (UIColor *)VLCLightTextColor
++ (nonnull UIColor *)VLCLightTextColor
 {
     return [UIColor colorWithWhite:.72 alpha:1.];
 }
 
-+ (UIColor *)VLCDarkFadedTextColor {
++ (nonnull UIColor *)VLCDarkFadedTextColor {
     return [UIColor colorWithRed:0.33 green:0.33 blue:0.33 alpha:1.0];
 }
 
-+ (UIColor *)VLCDarkTextColor
++ (nonnull UIColor *)VLCDarkTextColor
 {
     return [UIColor colorWithWhite:.28 alpha:1.];
 }
 
-+ (UIColor *)VLCDarkTextShadowColor
++ (nonnull UIColor *)VLCDarkTextShadowColor
 {
     return [UIColor colorWithWhite:0. alpha:.25f];
 }
 
-+ (UIColor *)VLCMenuBackgroundColor
++ (nonnull UIColor *)VLCMenuBackgroundColor
 {
     return [UIColor colorWithWhite:.17f alpha:1.];
 }
 
-+ (UIColor *)VLCOrangeTintColor
++ (nonnull UIColor *)VLCOrangeTintColor
 {
     return [UIColor colorWithRed:1.0f green:(132.0f/255.0f) blue:0.0f alpha:1.f];
 }

--- a/Sources/VLCMiniPlaybackView.m
+++ b/Sources/VLCMiniPlaybackView.m
@@ -209,12 +209,13 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
 
 - (void)displayMetadataForPlaybackController:(VLCPlaybackController *)controller metadata:(VLCMetaData *)metadata
 {
-    _videoView.hidden = YES;
     if (metadata.isAudioOnly) {
         _artworkView.contentMode = UIViewContentModeScaleAspectFill;
         _artworkView.image = metadata.artworkImage?: [UIImage imageNamed:@"no-artwork"];
+        _videoView.hidden = YES;
     } else {
         _artworkView.image = nil;
+        _videoView.hidden = NO;
     }
 
     NSString *metaDataString;

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1160,8 +1160,7 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self->_metadata updateMetadataFromMediaPlayer:self->_mediaPlayer];
             self->_needsMetadataUpdate = NO;
-            if ([self.delegate respondsToSelector:@selector(displayMetadataForPlaybackController:metadata:)])
-                [self.delegate displayMetadataForPlaybackController:self metadata:self->_metadata];
+            [self recoverDisplayedMetadata];
         });
     }
 }

--- a/Sources/VLCPlayerDisplayController.h
+++ b/Sources/VLCPlayerDisplayController.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSUInteger, VLCPlayerDisplayControllerDisplayMode) {
 
 @property (nonatomic, assign) VLCPlayerDisplayControllerDisplayMode displayMode;
 @property (nonatomic, weak) VLCPlaybackController *playbackController;
+@property (nonatomic, strong) NSLayoutYAxisAnchor *realBottomAnchor;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -318,7 +318,13 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
                               delay:animationDuration
                             options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
                          animations:^{
-                             self.bottomConstraint.constant = needsHide ? 0 : -self->_miniPlaybackView.frame.size.height -self.view.layoutMargins.bottom;
+                             self.bottomConstraint.active = NO;
+                             if (needsShow) {
+                                 self.bottomConstraint = [miniPlaybackView.bottomAnchor constraintEqualToAnchor:self.realBottomAnchor];
+                             } else {
+                                 self.bottomConstraint = [miniPlaybackView.topAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor];
+                             }
+                             self.bottomConstraint.active = YES;
                              [self.view layoutIfNeeded];
                          }
                          completion:completionBlock];

--- a/Sources/VLCSettingsTableViewCell.swift
+++ b/Sources/VLCSettingsTableViewCell.swift
@@ -57,7 +57,7 @@ class VLCSettingsTableViewCell: UITableViewCell {
         case kIASKOpenURLSpecifier:
             break
         default:
-            assertionFailure("\(specifier.type()) has not been defined for VLCSettingsTableViewCell")
+            assertionFailure("\(specifier.type() ?? "nil") has not been defined for VLCSettingsTableViewCell")
         }
     }
     


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Before, pausing a video via the mini player would completely hide the video thumbnail, and it would stay hidden even after re-starting the video. With this change, we hide the video view when playing audio, and show it otherwise.