### PR TITLE
Multiple file selection from iCloud drive

### DIFF
--- a/Sources/VLCDocumentPickerController.m
+++ b/Sources/VLCDocumentPickerController.m
@@ -22,13 +22,31 @@
 
 #pragma mark - Internal Methods
 
+- (UIViewController *) configurePickerViewController {
+    NSArray *types = @[(id)kUTTypeAudiovisualContent];
+    UIDocumentPickerMode mode = UIDocumentPickerModeImport;
+
+    if (@available(iOS 11.2, *)) {
+        // UIDocumentMenuViewController deprecated and does not support multiple selection
+        UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes: types inMode:mode];
+        picker.delegate = self;
+        picker.allowsMultipleSelection = YES;
+
+        return picker;
+    } else {
+        UIDocumentMenuViewController *importMenu = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:@[(id)kUTTypeAudiovisualContent] inMode:UIDocumentPickerModeImport];
+        importMenu.delegate = self;
+
+        return importMenu;
+    }
+}
+
 - (void)showDocumentMenuViewController:(id)sender
 {
-    UIDocumentMenuViewController *importMenu = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:@[(id)kUTTypeAudiovisualContent] inMode:UIDocumentPickerModeImport];
-    importMenu.delegate = self;
+    UIViewController *picker = [self configurePickerViewController];
 
     UIViewController *rootVC = [UIApplication sharedApplication].keyWindow.rootViewController;
-    UIPopoverPresentationController *popoverPres = importMenu.popoverPresentationController;
+    UIPopoverPresentationController *popoverPres = picker.popoverPresentationController;
 
     if (popoverPres) { // not-nil on iPad
         UIView *sourceView = nil;
@@ -43,7 +61,7 @@
         popoverPres.permittedArrowDirections = UIPopoverArrowDirectionLeft;
     }
 
-    [rootVC presentViewController:importMenu animated:YES completion:nil];
+    [rootVC presentViewController:picker animated:YES completion:nil];
 }
 
 #pragma mark - UIDocumentMenuDelegate
@@ -56,6 +74,13 @@
 }
 
 #pragma mark - UIDocumentPickerDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray <NSURL *>*)urls NS_AVAILABLE_IOS(11_0);
+{
+    for (NSURL *url in urls) {
+        [self documentPicker:controller didPickDocumentAtURL:url];
+    }
+}
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentAtURL:(NSURL *)url
 {
@@ -76,7 +101,6 @@
         [alert addAction:okAction];
         [rootVC presentViewController:alert animated:true completion:nil];
     }
-
 }
 
 @end


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Used `UIDocumentMenuViewController` is deprecated and doesn't support multiple file selection.
As for listening audiobooks from iCloud (I save them via Siri Shortcuts command) it is important to select all chapters without extra clicks (no I need to select them all separately).
So (as Apple suggests) I used `UIDocumentPickerViewController` for iOS 11.2 and later ([here I've read about its bugs in iOS 11 and iOS 11.1](https://forums.developer.apple.com/thread/90068)) and added extra delegate method to support multiple selected files.

That's all. Tiny changes for more power in the best media player!
