### PR TITLE
VLCMovieViewController: fix wrong padding on the sides on iPad

### DIFF
--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -405,7 +405,7 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
 
         NSObject *guide = self.navigationController.navigationBar;
         if (@available(iOS 11.0, *)) {
-            guide = self.navigationController.navigationBar.safeAreaLayoutGuide;
+            guide = self.navigationController.navigationBar.layoutMarginsGuide;
         }
 
         [NSLayoutConstraint activateConstraints:@[


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
old : 
<img width="897" alt="screen shot 2018-11-06 at 3 18 59 pm" src="https://user-images.githubusercontent.com/2445653/48070115-672caf00-e1d7-11e8-8156-f7294025cb83.png">
vs new:
<img width="885" alt="screen shot 2018-11-06 at 3 09 02 pm" src="https://user-images.githubusercontent.com/2445653/48070117-698f0900-e1d7-11e8-9ced-3621f531edfd.png">
it didn't look like it broke anything on iPhone X 