### PR TITLE
VLCMovieViewControlPanel: adjust for iPad Pro to not be completely fl…

### DIFF
--- a/Sources/VLCMovieViewControlPanelView.m
+++ b/Sources/VLCMovieViewControlPanelView.m
@@ -2,7 +2,7 @@
  * VLCMovieViewControlPanelView.m
  * VLC for iOS
  *****************************************************************************
- * Copyright (c) 2015 VideoLAN. All rights reserved.
+ * Copyright (c) 2015-2018 VideoLAN. All rights reserved.
  * $Id$
  *
  * Authors: Tobias Conradi <videolan@tobias-conradi.de>
@@ -186,7 +186,12 @@ static const CGFloat maxControlsWidth = 474.0;
                                                                                  metrics:nil
                                                                                    views:viewsDict]];
     } else {
-        [_constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[volume(>=150)]-(>=8)-[playback]-(>=8)-[speed(35)]-[track(35)]-[filter(35)]-[actions(35)]-|"
+        [_constraints addObjectsFromArray:@[
+                                            [self.volumeView.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor constant:8],
+                                            [self.moreActionsButton.trailingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor constant:-8],
+                                            ]];
+
+        [_constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[volume(>=150)]-(>=8)-[playback]-(>=8)-[speed(35)]-[track(35)]-[filter(35)]-[actions(35)]"
                                                                                  options:NSLayoutFormatAlignAllCenterY
                                                                                  metrics:nil
                                                                                    views:viewsDict]];


### PR DESCRIPTION
…ush against the border

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This pr makes sure that the volumeview and actionbutton are not flush with the edges but layout in respect to the layoutmargin on iPads 