### PR TITLE
fix text color in iCloud file selection (was white on white - unreadable)

### DIFF
--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -215,6 +215,9 @@ NSString *const VLCDropboxSessionWasAuthorized = @"VLCDropboxSessionWasAuthorize
     [[UINavigationBar appearance] setBarTintColor:vlcOrange];
     [[UINavigationBar appearanceWhenContainedInInstancesOfClasses:@[[VLCPlaybackNavigationController class]]] setBarTintColor: nil];
     [[UINavigationBar appearance] setTintColor:[UIColor whiteColor]];
+    if (@available(iOS 11.0, *)) {
+        [[UINavigationBar appearanceWhenContainedInInstancesOfClasses:@[[UIDocumentBrowserViewController class]]] setTintColor: vlcOrange];
+    }
     [[UINavigationBar appearance] setTitleTextAttributes: @{ NSForegroundColorAttributeName : [UIColor whiteColor] }];
     // For the edit selection indicators
     [[UITableView appearance] setTintColor:vlcOrange];


### PR DESCRIPTION

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [-] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
> Could not find 'lint'. Available lanes: release, ci, test
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

> Could not find 'lint'. Available lanes: release, ci, test

Well, I was very glad that now I can use multiselection from iCloud.
BUT: it has white text on white blurry background - so it is unreadable!

![photo_2018-11-22_12-27-50](https://user-images.githubusercontent.com/1945749/48893779-2af18380-ee52-11e8-80ed-110de52cd522.jpg)

I've checked again old master - it worked great!

I've investigated that work with UIAppearance in master and in release are different. Master has swift code for two themes and it shows orangeVLC text color on white blurry background. But release branch is different: tintColor is set to white that causes terrible behavior.

Please accept this change to fix text color in release branch.

Thank you.