### PR TITLE
skip NSFileWriteFileExistsError (code 516)

### DIFF
--- a/Sources/VLCDocumentPickerController.m
+++ b/Sources/VLCDocumentPickerController.m
@@ -92,6 +92,8 @@
     [fileManager moveItemAtPath:[url path] toPath:filePath error:&error];
     if (!error) {
         [[VLCMediaFileDiscoverer sharedInstance] updateMediaList];
+    } else if (error.domain == NSCocoaErrorDomain && error.code == NSFileWriteFileExistsError) {
+        // skip it
     } else {
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"GDRIVE_ERROR_DOWNLOADING_FILE_TITLE", nil) message:error.description preferredStyle:UIAlertControllerStyleAlert];
         UIViewController *rootVC = [UIApplication sharedApplication].keyWindow.rootViewController;


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md) and run `bundle exec fastlane lint` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Adding full folder frequently causes NSFileWriteFileExistsError (516) - for every previously added file.
Just skip it without fullscreen alert.
