### PR TITLE
MovieViewcontroller: adjust status message to say backward or forward…

### DIFF
--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -1480,7 +1480,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
     if (!_seekGestureEnabled)
         return;
 
-    NSString * hudString = @" ";
+    NSString *hudString = @" ";
 
     int swipeForwardDuration = (_variableJumpDurationEnabled) ? ((int)(_mediaDuration*0.001*0.05)) : FORWARD_SWIPE_DURATION;
     int swipeBackwardDuration = (_variableJumpDurationEnabled) ? ((int)(_mediaDuration*0.001*0.05)) : BACKWARD_SWIPE_DURATION;
@@ -1498,15 +1498,15 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
             [_vpc jumpForward:(timeRemaining - 5)];
             hudString = [NSString stringWithFormat:@"⇒ %is",(timeRemaining - 5)];
         }
-    }
-    else if (swipeRecognizer.direction == UISwipeGestureRecognizerDirectionLeft) {
+    } else if (swipeRecognizer.direction == UISwipeGestureRecognizerDirectionLeft) {
         [_vpc jumpBackward:swipeBackwardDuration];
         hudString = [NSString stringWithFormat:@"⇐ %is",swipeBackwardDuration];
-    }else if (swipeRecognizer.direction == UISwipeGestureRecognizerDirectionUp) {
+    } else if (swipeRecognizer.direction == UISwipeGestureRecognizerDirectionUp) {
         [self backward:self];
-    }
-    else if (swipeRecognizer.direction == UISwipeGestureRecognizerDirectionDown) {
+        hudString = NSLocalizedString(@"BWD_BUTTON", "");
+    } else if (swipeRecognizer.direction == UISwipeGestureRecognizerDirectionDown) {
         [self forward:self];
+        hudString = NSLocalizedString(@"FWD_BUTTON", "");
     }
 
     if (swipeRecognizer.state == UIGestureRecognizerStateEnded) {


### PR DESCRIPTION
… instead being empty

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
