### PR TITLE
Fixopen activity securty issue

### DIFF
--- a/Sources/VLC for iOS-Info.plist
+++ b/Sources/VLC for iOS-Info.plist
@@ -114,7 +114,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.4</string>
+	<string>3.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -242,7 +242,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>317</string>
+	<string>318</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -284,7 +284,9 @@ continueUserActivity:(NSUserActivity *)userActivity
             APLog(@"%s file not found: %@",__PRETTY_FUNCTION__,userActivity);
             return NO;
         }
-        [[VLCPlaybackController sharedInstance] openMediaLibraryObject:managedObject];
+        [self validatePasscodeIfNeededWithCompletion:^{
+            [[VLCPlaybackController sharedInstance] openMediaLibraryObject:managedObject];
+        }];
         return YES;
     }
     return NO;

--- a/VLC WatchKit Native Extension/Info.plist
+++ b/VLC WatchKit Native Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.4</string>
+	<string>3.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>317</string>
+	<string>318</string>
 	<key>MLKitGroupIdentifier</key>
 	<string>$(GROUP_IDENTIFIER)</string>
 	<key>NSExtension</key>

--- a/VLC WatchKit Native/Info.plist
+++ b/VLC WatchKit Native/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.4</string>
+	<string>3.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>317</string>
+	<string>318</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
 if you were jumping in through an activity you were able to bypass the passcode screen