### PR TITLE
VLCMediaLibraryManager: we have to wait until parsing of media is done

### DIFF
--- a/SharedSources/VLCMediaLibraryManager.swift
+++ b/SharedSources/VLCMediaLibraryManager.swift
@@ -79,7 +79,7 @@ class VLCMediaLibraryManager: NSObject {
     private static let migrationKey: String = "MigratedToVLCMediaLibraryKit"
 
     private var didMigrate = UserDefaults.standard.bool(forKey: VLCMediaLibraryManager.migrationKey)
-
+    private var didFinishDiscovery = false
     // Using ObjectIdentifier to avoid duplication and facilitate
     // identification of observing object
     private var observers = [ObjectIdentifier: Observer]()
@@ -456,12 +456,15 @@ extension VLCMediaLibraryManager {
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didCompleteDiscovery entryPoint: String) {
-        startMigrationIfNeeded()
+        didFinishDiscovery = true
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didProgressDiscovery entryPoint: String) {
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didUpdateParsingStatsWithPercent percent: UInt32) {
+        if didFinishDiscovery && percent == 100 {
+             startMigrationIfNeeded()
+        }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
