### PR TITLE
Onedrive: Fix hierarchy navigation issue

### DIFF
--- a/Sources/VLCOneDriveController.h
+++ b/Sources/VLCOneDriveController.h
@@ -33,6 +33,7 @@
 - (NSString *)configureSubtitleWithFileName:(NSString *)fileName folderItems:(NSArray *)folderItems;
 
 - (void)loadODItems;
+- (void)loadODParentItem;
 - (void)loadODItemsWithCompletionHandler:(void (^)(void))completionHandler;
 
 @end

--- a/Sources/VLCOneDriveController.m
+++ b/Sources/VLCOneDriveController.m
@@ -217,25 +217,49 @@
                 completionHandler();
             }
         } else {
-            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[error localizedFailureReason]
-                                                                                     message:[error localizedDescription]
-                                                                              preferredStyle:UIAlertControllerStyleAlert];
+            [weakSelf handleLoadODItemErrorWithError:error itemID:itemID];
+        }
+    }];
+}
 
-            UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"BUTTON_OK", nil)
-                                                               style:UIAlertActionStyleCancel
-                                                             handler:^(UIAlertAction *alertAction) {
-                                                                 if (weakSelf.presentingViewController && [itemID isEqualToString:@"root"]) {
-                                                                     [weakSelf.presentingViewController.navigationController popViewControllerAnimated:YES];
-                                                                 }
-                                                             }];
+- (void)handleLoadODItemErrorWithError:(NSError *)error itemID:(NSString *)itemID
+{
+    __weak typeof(self) weakSelf = self;
 
-            [alertController addAction:okAction];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[error localizedFailureReason]
+                                                                             message:[error localizedDescription]
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
 
-            if (weakSelf.presentingViewController) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [weakSelf.presentingViewController presentViewController:alertController animated:YES completion:nil];
-                });
-            }
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"BUTTON_OK", nil)
+                                                       style:UIAlertActionStyleCancel
+                                                     handler:^(UIAlertAction *alertAction) {
+                                                         if (weakSelf.presentingViewController && [itemID isEqualToString:@"root"]) {
+                                                             [weakSelf.presentingViewController.navigationController popViewControllerAnimated:YES];
+                                                         }
+                                                     }];
+
+    [alertController addAction:okAction];
+
+    if (weakSelf.presentingViewController) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.presentingViewController presentViewController:alertController animated:YES completion:nil];
+        });
+    }
+}
+
+- (void)loadODParentItem
+{
+    NSString *parentID = _parentItem.id ? _parentItem.id : @"root";
+
+    ODItemRequest *request = [[[_oneDriveClient drive] items:parentID] request];
+
+    __weak typeof(self) weakSelf = self;
+
+    [request getWithCompletion:^(ODItem *response, NSError *error) {
+        if (!error) {
+            weakSelf.parentItem = response;
+        } else {
+            [weakSelf handleLoadODItemErrorWithError:error itemID:parentID];
         }
     }];
 }

--- a/Sources/VLCOneDriveTableViewController.m
+++ b/Sources/VLCOneDriveTableViewController.m
@@ -81,6 +81,7 @@
         }
         [self.activityIndicator startAnimating];
         [_oneDriveController loadODItems];
+        [_oneDriveController loadODParentItem];
     } else {
         // We're at root, we need to pop the view
         [self.navigationController popViewControllerAnimated:YES];

--- a/Sources/VLCOneDriveTableViewController.m
+++ b/Sources/VLCOneDriveTableViewController.m
@@ -79,6 +79,7 @@
             _oneDriveController.currentItem = [[ODItem alloc] initWithDictionary:_oneDriveController.parentItem.dictionaryFromItem];
             _oneDriveController.parentItem.id = _oneDriveController.parentItem.parentReference.id;
         }
+        self.title = _oneDriveController.currentItem.name;
         [self.activityIndicator startAnimating];
         [_oneDriveController loadODItems];
         [_oneDriveController loadODParentItem];


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

During the `goBack` method, we're only setting the parentID. This led to navigation failure when the hierarchy had more than 3 folders. With this patch, we now load the `parentItem`  that loads its `parentReference`.
