### PR TITLE
Actionsheet: Add dismiss animation

### DIFF
--- a/Sources/VLCActionSheet/VLCActionSheet.swift
+++ b/Sources/VLCActionSheet/VLCActionSheet.swift
@@ -158,7 +158,7 @@ class VLCActionSheet: UIViewController {
 
     fileprivate func setupMainStackViewConstraints() {
         NSLayoutConstraint.activate([
-            mainStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 10),
             mainStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             mainStackView.widthAnchor.constraint(equalTo: view.widthAnchor),
             mainStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)

--- a/Sources/VLCActionSheet/VLCActionSheet.swift
+++ b/Sources/VLCActionSheet/VLCActionSheet.swift
@@ -109,62 +109,6 @@ class VLCActionSheet: UIViewController {
         return bottomBackgroundViewHeightConstraint
     }()
 
-    @objc func removeActionSheet() {
-        let realMainStackView = mainStackView.frame
-
-        UIView.animate(withDuration: 0.55, delay: 0,
-                       usingSpringWithDamping: 1,
-                       initialSpringVelocity: 0,
-                       options: .curveEaseIn,
-                       animations: {
-                        [mainStackView, backgroundView] in
-                        // Dismiss the mainStackView to the bottom of the screen
-                        mainStackView.frame.origin.y += mainStackView.frame.size.height
-                        backgroundView.alpha = 0
-            }, completion: {
-                [presentingViewController] finished in
-                presentingViewController?.dismiss(animated: false,
-                                                        completion: {
-                                                            [unowned self] in
-                                                            // When everything is complete, reset the frame for the re-use
-                                                            self.mainStackView.frame = realMainStackView
-                })
-        })
-    }
-
-    // MARK: Private methods
-
-    fileprivate func setuplHeaderViewConstraints() {
-        NSLayoutConstraint.activate([
-            headerView.heightAnchor.constraint(equalToConstant: cellHeight),
-            headerView.widthAnchor.constraint(equalTo: view.widthAnchor),
-            ])
-    }
-
-    fileprivate func setupCollectionViewConstraints() {
-        NSLayoutConstraint.activate([
-            collectionViewHeightConstraint,
-            maxCollectionViewHeightConstraint,
-            collectionView.widthAnchor.constraint(equalTo: view.widthAnchor),
-            ])
-    }
-
-    fileprivate func setupBottomBackgroundView() {
-        NSLayoutConstraint.activate([
-            bottomBackgroundViewHeightConstraint,
-            bottomBackgroundView.widthAnchor.constraint(equalTo: view.widthAnchor)
-            ])
-    }
-
-    fileprivate func setupMainStackViewConstraints() {
-        NSLayoutConstraint.activate([
-            mainStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 10),
-            mainStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            mainStackView.widthAnchor.constraint(equalTo: view.widthAnchor),
-            mainStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-            ])
-    }
-
     override func updateViewConstraints() {
         super.updateViewConstraints()
 
@@ -250,10 +194,6 @@ class VLCActionSheet: UIViewController {
         collectionView.collectionViewLayout.invalidateLayout()
     }
 
-    @objc func setAction(closure action: @escaping (_ item: Any) -> Void) {
-        self.action = action
-    }
-    
     @objc fileprivate func updateTheme() {
         collectionView.backgroundColor = PresentationTheme.current.colors.background
         headerView.backgroundColor = PresentationTheme.current.colors.background
@@ -266,6 +206,73 @@ class VLCActionSheet: UIViewController {
             }
         }
         collectionView.layoutIfNeeded()
+    }
+}
+
+// MARK: Private setup methods
+
+private extension VLCActionSheet {
+    private func setuplHeaderViewConstraints() {
+        NSLayoutConstraint.activate([
+            headerView.heightAnchor.constraint(equalToConstant: cellHeight),
+            headerView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            ])
+    }
+
+    private func setupCollectionViewConstraints() {
+        NSLayoutConstraint.activate([
+            collectionViewHeightConstraint,
+            maxCollectionViewHeightConstraint,
+            collectionView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            ])
+    }
+
+    private func setupBottomBackgroundView() {
+        NSLayoutConstraint.activate([
+            bottomBackgroundViewHeightConstraint,
+            bottomBackgroundView.widthAnchor.constraint(equalTo: view.widthAnchor)
+            ])
+    }
+
+    private func setupMainStackViewConstraints() {
+        NSLayoutConstraint.activate([
+            // Extra padding for spring animation
+            mainStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 10),
+            mainStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mainStackView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+    }
+}
+
+// MARK: Actions
+
+extension VLCActionSheet {
+    @objc func setAction(closure action: @escaping (_ item: Any) -> Void) {
+        self.action = action
+    }
+
+    @objc func removeActionSheet() {
+        let realMainStackView = mainStackView.frame
+
+        UIView.animate(withDuration: 0.55, delay: 0,
+                       usingSpringWithDamping: 1,
+                       initialSpringVelocity: 0,
+                       options: .curveEaseIn,
+                       animations: {
+                        [mainStackView, backgroundView] in
+                        // Dismiss the mainStackView to the bottom of the screen
+                        mainStackView.frame.origin.y += mainStackView.frame.size.height
+                        backgroundView.alpha = 0
+            }, completion: {
+                [presentingViewController] finished in
+                presentingViewController?.dismiss(animated: false,
+                                                  completion: {
+                                                    [unowned self] in
+                                                    // When everything is complete, reset the frame for the re-use
+                                                    self.mainStackView.frame = realMainStackView
+                })
+        })
     }
 }
 

--- a/Sources/VLCActionSheet/VLCActionSheet.swift
+++ b/Sources/VLCActionSheet/VLCActionSheet.swift
@@ -157,14 +157,10 @@ class VLCActionSheet: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        setHeaderRoundedCorners()
+
         // This is to avoid a horrible visual glitch!
         mainStackView.isHidden = false
-
-        let roundedCornerPath = UIBezierPath(roundedRect: headerView.bounds, byRoundingCorners: [.topLeft, .topRight],
-                                             cornerRadii: CGSize(width: 10, height: 10))
-        let maskLayer = CAShapeLayer()
-        maskLayer.path = roundedCornerPath.cgPath
-        headerView.layer.mask = maskLayer
 
         let realMainStackView = mainStackView.frame
 
@@ -186,6 +182,7 @@ class VLCActionSheet: UIViewController {
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.maxCollectionViewHeightConstraint.constant = size.height / 2
             self?.collectionView.layoutIfNeeded()
+            self?.setHeaderRoundedCorners()
         })
     }
 
@@ -242,6 +239,18 @@ private extension VLCActionSheet {
             mainStackView.widthAnchor.constraint(equalTo: view.widthAnchor),
             mainStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ])
+    }
+}
+
+// MARK: Helpers
+
+private extension VLCActionSheet {
+    private func setHeaderRoundedCorners() {
+        let roundedCornerPath = UIBezierPath(roundedRect: headerView.bounds, byRoundingCorners: [.topLeft, .topRight],
+                                             cornerRadii: CGSize(width: 10, height: 10))
+        let maskLayer = CAShapeLayer()
+        maskLayer.path = roundedCornerPath.cgPath
+        headerView.layer.mask = maskLayer
     }
 }
 


### PR DESCRIPTION
This adds a dismiss animation so that the user isn't flashed by a
flashed by the default animation.

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This improves the overall animation of the action sheet dismissal.

`4e58a56` Could have been into a separate PR but with the "tidy-upping" I found it can be more trouble.
If really needed, I can make a separate PR.
