### PR TITLE
Avoid implementing unsupported orientation method on tvOS

### DIFF
--- a/Sources/VLCPlaybackNavigationController.m
+++ b/Sources/VLCPlaybackNavigationController.m
@@ -14,9 +14,11 @@
 
 @implementation VLCPlaybackNavigationController
 
+#if !TARGET_OS_TV
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     return [self.topViewController supportedInterfaceOrientations];
 }
+#endif
 
 @end


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
When building for tvOS, one of the iOS/tvOS shared sources attempts to implement an interface orientation method that is unavailable on tvOS. This patch skips that when the target is tvOS.

Note that I'm told the tests don't really test the tvOS side, but it builds and runs on my Apple TV before and after the patch, and without the Xcode warning.