### PR TITLE
Import VLCTVConstants.h instead when building tvOS

### DIFF
--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -20,7 +20,11 @@
 #import "UIDevice+VLC.h"
 #import <AVFoundation/AVFoundation.h>
 #import "VLCPlayerDisplayController.h"
+#if TARGET_OS_TV
+#import "VLCTVConstants.h"
+#else
 #import "VLCConstants.h"
+#endif
 #import "VLCRemoteControlService.h"
 #import "VLCMetadata.h"
 #if TARGET_OS_IOS


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
Xcode has been objecting to redefinition of kSupportedFileFormats, which stems from VLCConstants.h being imported by VLCPlaybackController.m when it should be using VLCTVConstants.h instead.

This patch conditionally loads the correct Constants or TVConstants file, rather than assuming Constants is correct, which _seems_ to repair the error.

I am not at all certain this is the most correct approach, but in any case on the theory that fewer Xcode warnings are better over time, duly proposed.