### PR TITLE
Add edit cell for audio

### DIFF
--- a/SharedSources/MediaEditCell.xib
+++ b/SharedSources/MediaEditCell.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.59" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.45"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,14 +27,20 @@
                             </constraints>
                         </imageView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W4f-6Y-az7">
-                            <rect key="frame" x="40" y="0.0" width="99" height="62"/>
+                            <rect key="frame" x="40" y="6" width="80" height="50"/>
                             <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>
-                                <constraint firstAttribute="width" secondItem="W4f-6Y-az7" secondAttribute="height" multiplier="16:10" id="o2R-2I-WPK"/>
+                                <constraint firstAttribute="width" secondItem="W4f-6Y-az7" secondAttribute="height" multiplier="1:1" id="0S0-Dm-pFV" userLabel="AudioAspectt = 1:1"/>
+                                <constraint firstAttribute="width" secondItem="W4f-6Y-az7" secondAttribute="height" multiplier="16:10" id="o2R-2I-WPK" userLabel="VideoAspectRatio"/>
                             </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="0S0-Dm-pFV"/>
+                                </mask>
+                            </variation>
                         </imageView>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="ZiN-xT-sWh">
-                            <rect key="frame" x="159" y="11.5" width="192" height="39"/>
+                            <rect key="frame" x="140" y="11.5" width="211" height="39"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="22f-7o-NGo">
                                     <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
@@ -73,6 +78,8 @@
             </constraints>
             <viewLayoutGuide key="safeArea" id="Lgw-oV-ncW"/>
             <connections>
+                <outlet property="AudioAspectRatio" destination="0S0-Dm-pFV" id="fup-hh-pq5"/>
+                <outlet property="VideoAspectRatio" destination="o2R-2I-WPK" id="hQw-An-wIt"/>
                 <outlet property="checkboxImageView" destination="RHG-II-xmF" id="F6Y-7m-fPb"/>
                 <outlet property="sizeLabel" destination="ZKc-bz-v5I" id="wmF-9r-Gew"/>
                 <outlet property="thumbnailImageView" destination="W4f-6Y-az7" id="qx7-8D-QJK"/>

--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -52,6 +52,13 @@ extension AlbumModel {
     }
 }
 
+// MARK: - Edit
+extension AlbumModel: EditableMLModel {
+    func editCellType() -> BaseCollectionViewCell.Type {
+        return MediaEditCell.self
+    }
+}
+
 extension AlbumModel: MediaLibraryObserver {
     func medialibrary(_ medialibrary: VLCMediaLibraryManager, didAddAlbums albums: [VLCMLAlbum]) {
         albums.forEach({ append($0) })

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -38,6 +38,12 @@ class ArtistModel: MLBaseModel {
         preconditionFailure("ArtistModel: Cannot delete artist")
     }
 }
+// MARK: - Edit
+extension ArtistModel: EditableMLModel {
+    func editCellType() -> BaseCollectionViewCell.Type {
+        return MediaEditCell.self
+    }
+}
 
 // MARK: - Sort
 

--- a/SharedSources/MediaLibraryModel/AudioModel.swift
+++ b/SharedSources/MediaLibraryModel/AudioModel.swift
@@ -44,6 +44,12 @@ extension AudioModel {
     }
 }
 
+// MARK: - Edit
+extension AudioModel: EditableMLModel {
+    func editCellType() -> BaseCollectionViewCell.Type {
+        return MediaEditCell.self
+    }
+}
 // MARK: - MediaLibraryObserver
 
 extension AudioModel: MediaLibraryObserver {

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -56,6 +56,12 @@ extension GenreModel: MediaLibraryObserver {
     }
 }
 
+// MARK: - Edit
+extension GenreModel: EditableMLModel {
+    func editCellType() -> BaseCollectionViewCell.Type {
+        return MediaEditCell.self
+    }
+}
 extension VLCMLGenre {
     @objc func numberOfTracksString() -> String {
         let numberOftracks = numberOfTracks()

--- a/SharedSources/MediaLibraryModel/VideoModel.swift
+++ b/SharedSources/MediaLibraryModel/VideoModel.swift
@@ -37,7 +37,6 @@ class VideoModel: MediaModel {
 }
 
 // MARK: - Edit
-
 extension VideoModel: EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type {
         return MediaEditCell.self

--- a/Sources/MediaCategoryCells/AudioCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/AudioCollectionViewCell.swift
@@ -60,7 +60,7 @@ class AudioCollectionViewCell: BaseCollectionViewCell {
 
     func update(album: VLCMLAlbum) {
         titleLabel.text = album.title
-        descriptionLabel.text = album.albumArtist.name
+        descriptionLabel.text = album.albumArtist != nil ? album.albumArtist.name : ""
     }
 
     override class func cellSizeForWidth(_ width: CGFloat) -> CGSize {

--- a/Sources/MediaEditCell.swift
+++ b/Sources/MediaEditCell.swift
@@ -19,19 +19,27 @@ class MediaEditCell: BaseCollectionViewCell {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var timeLabel: UILabel!
     @IBOutlet weak var sizeLabel: UILabel!
+    @IBOutlet weak var VideoAspectRatio: NSLayoutConstraint!
+    @IBOutlet weak var AudioAspectRatio: NSLayoutConstraint!
 
     override var media: VLCMLObject? {
         didSet {
-            guard let media = media as? VLCMLMedia else {
-                fatalError("needs to be of Type VLCMLMedia")
+            if let media = media as? VLCMLMedia {
+                updateForMedia(media: media)
+            } else if let artist = media as? VLCMLArtist {
+                updateForArtist(artist: artist)
+            } else if let album = media as? VLCMLAlbum {
+                updateForAlbum(album: album)
+            } else if let genre = media as? VLCMLGenre {
+                updateForGenre(genre: genre)
+            } else {
+                fatalError("needs to be of a supported Type")
             }
-            update(media:media)
         }
     }
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        thumbnailImageView.layer.cornerRadius = 3
         thumbnailImageView.clipsToBounds = true
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: .VLCThemeDidChangeNotification, object: nil)
         themeDidChange()
@@ -44,13 +52,35 @@ class MediaEditCell: BaseCollectionViewCell {
         sizeLabel.textColor = PresentationTheme.current.colors.cellTextColor
     }
 
-    func update(media: VLCMLMedia) {
+    func updateForMedia(media: VLCMLMedia) {
+        thumbnailImageView.layer.cornerRadius = 3
+        AudioAspectRatio.isActive = false
+        VideoAspectRatio.isActive = true
         titleLabel.text = media.title
         timeLabel.text = media.mediaDuration()
         sizeLabel.text = media.formatSize()
         if media.isThumbnailGenerated() {
             thumbnailImageView.image = UIImage(contentsOfFile: media.thumbnail.absoluteString)
         }
+    }
+
+    func updateForArtist(artist: VLCMLArtist) {
+        //TODO: add size, number of tracks, thumbnail
+        titleLabel.text = artist.name
+        thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.size.height / 2
+    }
+
+    func updateForAlbum(album: VLCMLAlbum) {
+        titleLabel.text = album.title
+        timeLabel.text = album.albumArtist != nil ? album.albumArtist.name : ""
+        //TODO: add size, number of tracks, thumbnail
+    }
+
+    func updateForGenre(genre: VLCMLGenre) {
+        titleLabel.text = genre.name
+        timeLabel.text = genre.numberOfTracksString()
+        thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.size.height / 2
+        //TODO: add thumbnail
     }
 
     var isChecked: Bool = false {
@@ -66,5 +96,8 @@ class MediaEditCell: BaseCollectionViewCell {
         sizeLabel.text = ""
         thumbnailImageView.image = nil
         isChecked = false
+        thumbnailImageView.layer.cornerRadius = 0
+        AudioAspectRatio.isActive = true
+        VideoAspectRatio.isActive = false
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Currently the app crashes in some category when you hit edit to fix that I've adjusted the MediaEditCell to also handle all of our Audio models.
Once this is merged we have to write tickets for the todos in the last commit like adding file sizes and number of tracks for albums and removing the nil check for artist name. 
additionally for the Songs category the edit cell doesn't configure correctly based on the actual item type