### PR TITLE
MovieViewController: delete deprecated rotation method

### DIFF
--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -1649,12 +1649,6 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
            || toInterfaceOrientation != UIInterfaceOrientationPortraitUpsideDown;
 }
 
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
-{
-    if (_vpc.isPlaying && _controlsHidden)
-        [self setControlsHidden:NO animated:YES];
-}
-
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description

The function seems to have no effect - the device rotating is handled with or without this function