### PR TITLE
Fix migration

### DIFF
--- a/SharedSources/VLCMediaLibraryManager.swift
+++ b/SharedSources/VLCMediaLibraryManager.swift
@@ -79,7 +79,7 @@ class VLCMediaLibraryManager: NSObject {
     private static let migrationKey: String = "MigratedToVLCMediaLibraryKit"
 
     private var didMigrate = UserDefaults.standard.bool(forKey: VLCMediaLibraryManager.migrationKey)
-
+    private var didFinishDiscovery = false
     // Using ObjectIdentifier to avoid duplication and facilitate
     // identification of observing object
     private var observers = [ObjectIdentifier: Observer]()
@@ -456,12 +456,15 @@ extension VLCMediaLibraryManager {
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didCompleteDiscovery entryPoint: String) {
-        startMigrationIfNeeded()
+        didFinishDiscovery = true
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didProgressDiscovery entryPoint: String) {
     }
 
     func medialibrary(_ medialibrary: VLCMediaLibrary, didUpdateParsingStatsWithPercent percent: UInt32) {
+        if didFinishDiscovery && percent == 100 {
+             startMigrationIfNeeded()
+        }
     }
 }

--- a/SharedSources/VLCMediaLibraryManager.swift
+++ b/SharedSources/VLCMediaLibraryManager.swift
@@ -84,16 +84,14 @@ class VLCMediaLibraryManager: NSObject {
     // identification of observing object
     private var observers = [ObjectIdentifier: Observer]()
 
-    private lazy var medialib: VLCMediaLibrary = {
-        let medialibrary = VLCMediaLibrary()
-        medialibrary.delegate = self
-        return medialibrary
-    }()
+    private var medialib: VLCMediaLibrary!
 
     weak var migrationDelegate: MediaLibraryMigrationDelegate?
 
     override init() {
         super.init()
+        medialib = VLCMediaLibrary()
+        medialib.delegate = self
         setupMediaLibrary()
         NotificationCenter.default.addObserver(self, selector: #selector(reload),
                                                name: .VLCNewFileAddedNotification, object: nil)
@@ -180,15 +178,6 @@ class VLCMediaLibraryManager: NSObject {
         }
         return medialib.media(withMrl: mrl)
     }
-
-    @discardableResult
-    func prepareMigrationIfNeeded() -> Bool {
-        if !didMigrate {
-            migrationDelegate?.medialibraryDidStartMigration(self)
-            return true
-        }
-        return false
-    }
 }
 
 // MARK: - Migration
@@ -198,7 +187,7 @@ private extension VLCMediaLibraryManager {
         guard !didMigrate else {
             return
         }
-
+        migrationDelegate?.medialibraryDidStartMigration(self)
         guard migrateToNewMediaLibrary() else {
             migrationDelegate?.medialibraryDidStopMigration(self)
             return

--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -36,7 +36,6 @@ class Services: NSObject {
         // FIXME: VLCHTTPUploaderController should perhaps be a service?
         VLCHTTPUploaderController.sharedInstance().cleanCache()
         services.medialibraryManager.migrationDelegate = self
-        services.medialibraryManager.prepareMigrationIfNeeded()
     }
 
     private func setupChildViewControllers() {


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
follow up to https://github.com/videolan/vlc-ios/pull/190 
The tests discovered unbalanced calls in the migrationController that led to the migration controller never getting dismissed on a clean install. Two underlying issues were addressed here

1. There were two migration calls. prepareMigrationIfNeeded that showed the migration controller and startMigrationIfNeeded. This commit merges both calls to show the migration controller when the migration is actually happening.
 
2. After taking  close look at setupMedialibrary I noticed that the file discovery was being kicked off before the delegate was set since the medialibrary was lazily loaded. Therefor events were not getting received. The medialib is now immediately instantiated instead of lazily loaded.

Blocking the UI during migration is a relict from core data times where touching the database during migration crashes the system and should therefor be avoided. We have now the case where we start discovery and if we discover an old library show the migration controller with a delay after discovery is finished. 

Even though it's correct, UX wise this feels off and should be addressed in a follow up. 

Rough thoughts for follow up ticket. Two ways to address this:
1. We show the full migrationcontroller also during discovery but have the text reflect what's going on "initializing Medialib"  then "found old medialib now migrating". reason: We shouldn't show a user who made a new install a "migration view" even though there is nothing to migrate.

2. And I'd prefer this option. I believe there is no need anymore to block the UI but I would still want to give visual feedback of "initialising Medialib and migrating old data" so that when someone upgrades he understand why initially there is an empty Medialib.

Anyway there will be two Use cases that need to be covered 1. a new user 2. an old user with existing media and both deserve a great UX when first opening 3.2