### PR TITLE
Add collection controller

### DIFF
--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -62,3 +62,9 @@ extension AlbumModel: MediaLibraryObserver {
         updateView?()
     }
 }
+
+extension VLCMLAlbum: MediaCollectionModel {
+    func files() -> [VLCMLMedia] {
+        return tracks
+    }
+}

--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -64,6 +64,10 @@ extension AlbumModel: MediaLibraryObserver {
 }
 
 extension VLCMLAlbum: MediaCollectionModel {
+    func sortModel() -> SortModel? {
+        return nil
+    }
+
     func files() -> [VLCMLMedia] {
         return tracks
     }

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -63,6 +63,11 @@ extension ArtistModel: MediaLibraryObserver {
 }
 
 extension VLCMLArtist: MediaCollectionModel {
+
+    func sortModel() -> SortModel? {
+        return SortModel([.alpha])
+    }
+
     func files() -> [VLCMLMedia] {
         return []
     }

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -61,3 +61,9 @@ extension ArtistModel: MediaLibraryObserver {
         updateView?()
     }
 }
+
+extension VLCMLArtist: MediaCollectionModel {
+    func files() -> [VLCMLMedia] {
+        return []
+    }
+}

--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -1,0 +1,47 @@
+//
+//  CollectionModel.swift
+//  VLC-iOS
+//
+//  Created by Carola Nitz on 08.03.19.
+//  Copyright © 2019 VideoLAN. All rights reserved.
+//
+
+import Foundation
+
+class CollectionModel: MLBaseModel {
+
+    typealias MLType = VLCMLMedia // could be anything
+    required init(medialibrary: MediaLibraryService) {
+        preconditionFailure("")
+    }
+
+    required init(mediaService: MediaLibraryService, mediaCollection: MediaCollectionModel) {
+        self.medialibrary = mediaService
+        files = mediaCollection.files()
+    }
+
+    func append(_ item: VLCMLMedia) {
+        files.append(item)
+    }
+
+    var medialibrary: MediaLibraryService
+    var updateView: (() -> Void)?
+
+    var files = [VLCMLMedia]()
+
+    var cellType: BaseCollectionViewCell.Type { return AudioCollectionViewCell.self } //TODO: this approach will not work here because playlists can contain audio or videocells
+
+    var indicatorName: String = NSLocalizedString("Collections", comment: "")
+
+    func delete(_ items: [VLCMLObject]) {
+       assertionFailure("still needs implementation")
+    }
+}
+
+// MARK: - Edit
+extension CollectionModel: EditableMLModel {
+    func editCellType() -> BaseCollectionViewCell.Type {
+        return MediaEditCell.self
+    }
+}
+

--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 class CollectionModel: MLBaseModel {
+    var sortModel: SortModel
 
     typealias MLType = VLCMLMedia // could be anything
     required init(medialibrary: MediaLibraryService) {
@@ -18,6 +19,7 @@ class CollectionModel: MLBaseModel {
     required init(mediaService: MediaLibraryService, mediaCollection: MediaCollectionModel) {
         self.medialibrary = mediaService
         files = mediaCollection.files()
+        sortModel = mediaCollection.sortModel() ?? SortModel([.default])
     }
 
     func append(_ item: VLCMLMedia) {

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -71,3 +71,9 @@ extension VLCMLGenre {
         return String(format: NSLocalizedString("TRACK", comment: ""), numberOftracks)
     }
 }
+
+extension VLCMLGenre: MediaCollectionModel {
+    func files() -> [VLCMLMedia] {
+        return []
+    }
+}

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -73,6 +73,10 @@ extension VLCMLGenre {
 }
 
 extension VLCMLGenre: MediaCollectionModel {
+    func sortModel() -> SortModel? {
+        return SortModel([.alpha])
+    }
+
     func files() -> [VLCMLMedia] {
         return []
     }

--- a/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
@@ -72,4 +72,5 @@ protocol EditableMLModel {
 
 protocol MediaCollectionModel {
     func files() -> [VLCMLMedia]
+    func sortModel() -> SortModel?
 }

--- a/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
@@ -69,3 +69,7 @@ protocol EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type
 
 }
+
+protocol MediaCollectionModel {
+    func files() -> [VLCMLMedia]
+}

--- a/SharedSources/MediaLibraryModel/PlaylistModel.swift
+++ b/SharedSources/MediaLibraryModel/PlaylistModel.swift
@@ -87,3 +87,9 @@ extension VLCMLPlaylist {
         return String(format: tracksString, media.count)
     }
 }
+
+extension VLCMLPlaylist: MediaCollectionModel {
+    func files() -> [VLCMLMedia] {
+        return media
+    }
+}

--- a/SharedSources/MediaLibraryModel/PlaylistModel.swift
+++ b/SharedSources/MediaLibraryModel/PlaylistModel.swift
@@ -89,6 +89,10 @@ extension VLCMLPlaylist {
 }
 
 extension VLCMLPlaylist: MediaCollectionModel {
+    func sortModel() -> SortModel? {
+        return nil
+    }
+
     func files() -> [VLCMLMedia] {
         return media
     }

--- a/Sources/MediaCategories/MediaCategory.swift
+++ b/Sources/MediaCategories/MediaCategory.swift
@@ -79,3 +79,13 @@ class VLCAlbumCategoryViewController: VLCMediaCategoryViewController {
         }
     }
 }
+
+class VLCCollectionCategoryViewController: VLCMediaCategoryViewController {
+    init(_ services: Services, mediaCollection: MediaCollectionModel) {
+        let model = CollectionModel(mediaService: services.medialibraryService, mediaCollection: mediaCollection)
+        super.init(services: services, model: model)
+        model.updateView = { [weak self] in
+            self?.reloadData()
+        }
+    }
+}

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -20,6 +20,7 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
     private var services: Services
     private var searchController: UISearchController?
     private let searchDataSource = VLCLibrarySearchDisplayDataSource()
+    private var rendererButton: UIButton
     private lazy var editController: VLCEditController = {
         let editController = VLCEditController(mediaLibraryService:services.medialibraryService, model: model)
         editController.delegate = self
@@ -72,8 +73,10 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
     init(services: Services, model: MediaLibraryBaseModel) {
         self.services = services
         self.model = model
+        self.rendererButton = services.rendererDiscovererManager.setupRendererButton()
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: .VLCThemeDidChangeNotification, object: nil)
+        navigationItem.rightBarButtonItems = [editButtonItem, UIBarButtonItem(customView: rendererButton)]
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -227,6 +230,9 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let media = model.anyfiles[indexPath.row] as? VLCMLMedia {
             play(media: media)
+        } else if let mediaCollection = model.anyfiles[indexPath.row] as? MediaCollectionModel {
+            let collectionViewController = VLCCollectionCategoryViewController(services, mediaCollection: mediaCollection)
+            navigationController?.pushViewController(collectionViewController, animated: true)
         }
     }
 }

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		411453B9219C48DA002D94E1 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 411453B8219C48DA002D94E1 /* Launch Screen.storyboard */; };
 		411DC0FD20F650B10044305E /* VLCMediaSubcategory+VLCDragAndDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412BE7521FC4947400ACCC42 /* VLCMediaSubcategory+VLCDragAndDrop.swift */; };
 		412086362231FE43006A6630 /* UIViewController+VLCAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3EABFB1BE14C4B003668DA /* UIViewController+VLCAlert.m */; };
-		4120863A22323E87006A6630 /* CollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4120863922323E87006A6630 /* CollectionModel.swift */; };
 		41251ED01FD0CF7900099110 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41251ECE1FD0CF7900099110 /* AppCoordinator.swift */; };
 		41273A3C1A955C4100A2EF77 /* VLCMigrationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 41273A3A1A955C4100A2EF77 /* VLCMigrationViewController.m */; };
 		41273A3D1A955C4100A2EF77 /* VLCMigrationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41273A3B1A955C4100A2EF77 /* VLCMigrationViewController.xib */; };
@@ -57,6 +56,7 @@
 		419A2C661F37A4B70069D224 /* VLCStringsForLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 419A2C651F37A4B70069D224 /* VLCStringsForLocalization.m */; };
 		419A2C681F37A4B70069D224 /* VLCStringsForLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 419A2C651F37A4B70069D224 /* VLCStringsForLocalization.m */; };
 		419D7F051F54176900AF69A2 /* VLCTimeNavigationTitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 419D7F041F54176900AF69A2 /* VLCTimeNavigationTitleView.xib */; };
+		41A780E52241EBCD0034BA74 /* CollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4120863922323E87006A6630 /* CollectionModel.swift */; };
 		41B4DA3E21400E8E000BA27D /* MediaEditCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41B4DA3D21400E8E000BA27D /* MediaEditCell.xib */; };
 		41B93C011A53833B00102E8B /* VLCProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = 41B93C001A53833B00102E8B /* VLCProgressView.m */; };
 		41B93C051A53835300102E8B /* VLCCloudServiceCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 41B93C031A53835300102E8B /* VLCCloudServiceCell.m */; };
@@ -2957,6 +2957,7 @@
 				8D43712D2056AF1600F36458 /* VLCRendererDiscovererManager.swift in Sources */,
 				7DC19AE41868C8EC00810BF7 /* VLCFirstStepsFirstPageViewController.m in Sources */,
 				7D3784AD183A9906009EE944 /* VLCDropboxController.m in Sources */,
+				41A780E52241EBCD0034BA74 /* CollectionModel.swift in Sources */,
 				7D3784AE183A9906009EE944 /* VLCDropboxTableViewController.m in Sources */,
 				7D3784BE183A9938009EE944 /* UIBarButtonItem+Theme.m in Sources */,
 				DD3EFF3B1BDEBCE500B68579 /* VLCNetworkServerBrowserVLCMedia.m in Sources */,

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		411453B9219C48DA002D94E1 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 411453B8219C48DA002D94E1 /* Launch Screen.storyboard */; };
 		411DC0FD20F650B10044305E /* VLCMediaSubcategory+VLCDragAndDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412BE7521FC4947400ACCC42 /* VLCMediaSubcategory+VLCDragAndDrop.swift */; };
 		412086362231FE43006A6630 /* UIViewController+VLCAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3EABFB1BE14C4B003668DA /* UIViewController+VLCAlert.m */; };
+		4120863A22323E87006A6630 /* CollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4120863922323E87006A6630 /* CollectionModel.swift */; };
 		41251ED01FD0CF7900099110 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41251ECE1FD0CF7900099110 /* AppCoordinator.swift */; };
 		41273A3C1A955C4100A2EF77 /* VLCMigrationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 41273A3A1A955C4100A2EF77 /* VLCMigrationViewController.m */; };
 		41273A3D1A955C4100A2EF77 /* VLCMigrationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41273A3B1A955C4100A2EF77 /* VLCMigrationViewController.xib */; };
@@ -424,6 +425,7 @@
 		3B75A76DF6589FE678357D42 /* Pods-VLC-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOS/Pods-VLC-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3E95DC30A81B2AF9F7442E00 /* Pods-VLC-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOSTests/Pods-VLC-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		411453B8219C48DA002D94E1 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		4120863922323E87006A6630 /* CollectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionModel.swift; sourceTree = "<group>"; };
 		41251ECB1FD0C5C100099110 /* VLC-iOS-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "VLC-iOS-Bridging-Header.h"; path = "vlc-ios/VLC-iOS-Bridging-Header.h"; sourceTree = SOURCE_ROOT; };
 		41251ECE1FD0CF7900099110 /* AppCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppCoordinator.swift; path = Sources/Coordinators/AppCoordinator.swift; sourceTree = SOURCE_ROOT; };
 		41273A391A955C4100A2EF77 /* VLCMigrationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VLCMigrationViewController.h; path = Sources/VLCMigrationViewController.h; sourceTree = SOURCE_ROOT; };
@@ -1918,6 +1920,7 @@
 				8DE18897210F144B00A091D2 /* GenreModel.swift */,
 				8DF966EE211C643D00D0FCD6 /* PlaylistModel.swift */,
 				8D4F9B462141630000E478BE /* MediaModel.swift */,
+				4120863922323E87006A6630 /* CollectionModel.swift */,
 			);
 			path = MediaLibraryModel;
 			sourceTree = "<group>";


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Is there a better approach than reusing the MediaCategoryViewController ? 
Instead of Creating 4 Controllers for an Album, a Playlist, an Artist, a Genre I've reused the CategoryViewController. Drawback is though that the required model wants one Cell for all medias which will be a problem for Playlists that can hold Movie and Audio cells.
I'm also unsure how to register for when files get added to an item of the above mentioned Collection types. probably have to dig into the media library here 