### PR TITLE
Sort: Use VLCActionSheet

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -326,6 +326,11 @@
 "RENAME_PLACEHOLDER" = "New title";
 "ERROR_RENAME_FAILED" = "Renaming failed";
 "ERROR_EMPTY_NAME" = "The title can't be empty";
+
+// Sort
+
+"HEADER_TITLE_SORT" = "Sort by";
+
 // VLCMediaLibraryKit - Sorting Criteria
 
 "ALPHA" = "Alphanumerically";

--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -12,10 +12,7 @@
 class AlbumModel: MLBaseModel {
     typealias MLType = VLCMLAlbum
 
-    var sortModel = SortModel(alpha: true,
-                              duration: true,
-                              releaseDate: true,
-                              trackNumber: true)
+    var sortModel = SortModel([.alpha, .duration, .releaseDate, .trackNumber])
 
     var updateView: (() -> Void)?
 

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -12,7 +12,7 @@
 class ArtistModel: MLBaseModel {
     typealias MLType = VLCMLArtist
 
-    var sortModel = SortModel(alpha: true)
+    var sortModel = SortModel([.alpha])
 
     var updateView: (() -> Void)?
 

--- a/SharedSources/MediaLibraryModel/AudioModel.swift
+++ b/SharedSources/MediaLibraryModel/AudioModel.swift
@@ -12,9 +12,7 @@
 class AudioModel: MediaModel {
     typealias MLType = VLCMLMedia
 
-    var sortModel = SortModel(alpha: true,
-                              duration: true,
-                              fileSize: true)
+    var sortModel = SortModel([.alpha, .duration, .fileSize])
 
     var updateView: (() -> Void)?
 

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -12,7 +12,7 @@
 class GenreModel: MLBaseModel {
     typealias MLType = VLCMLGenre
 
-    var sortModel = SortModel(alpha: true)
+    var sortModel = SortModel([.alpha])
 
     var updateView: (() -> Void)?
 

--- a/SharedSources/MediaLibraryModel/PlaylistModel.swift
+++ b/SharedSources/MediaLibraryModel/PlaylistModel.swift
@@ -12,8 +12,7 @@
 class PlaylistModel: MLBaseModel {
     typealias MLType = VLCMLPlaylist
 
-    var sortModel = SortModel(alpha: true,
-                              duration: true)
+    var sortModel = SortModel([.alpha, .duration])
 
     var updateView: (() -> Void)?
 

--- a/SharedSources/MediaLibraryModel/ShowEpisodeModel.swift
+++ b/SharedSources/MediaLibraryModel/ShowEpisodeModel.swift
@@ -12,11 +12,7 @@
 class ShowEpisodeModel: MLBaseModel {
     typealias MLType = VLCMLMedia
 
-    var sortModel = SortModel(alpha: true,
-                              duration: true,
-                              insertionDate: true,
-                              releaseDate: true,
-                              fileSize: true)
+    var sortModel = SortModel([.alpha, .duration, .insertionDate, .releaseDate, .fileSize])
 
     var updateView: (() -> Void)?
 

--- a/SharedSources/MediaLibraryModel/VideoModel.swift
+++ b/SharedSources/MediaLibraryModel/VideoModel.swift
@@ -12,11 +12,7 @@
 class VideoModel: MediaModel {
     typealias MLType = VLCMLMedia
 
-    var sortModel = SortModel(alpha: true,
-                              duration: true,
-                              insertionDate: true,
-                              releaseDate: true,
-                              fileSize: true)
+    var sortModel = SortModel([.alpha, .duration, .insertionDate, .releaseDate, .fileSize])
 
     var updateView: (() -> Void)?
 

--- a/Sources/Coordinators/SortModel.swift
+++ b/Sources/Coordinators/SortModel.swift
@@ -13,35 +13,12 @@
 struct SortModel {
     var currentSort: VLCMLSortingCriteria
     var desc: Bool
-    var sortingCriteria: [Bool]
+    var sortingCriteria: [VLCMLSortingCriteria]
 
-    init(alpha: Bool = true,
-         duration: Bool = false,
-         insertionDate: Bool = false,
-         lastModificationDate: Bool = false,
-         releaseDate: Bool = false,
-         fileSize: Bool = false,
-         artist: Bool = false,
-         playCount: Bool = false,
-         album: Bool = false,
-         filename: Bool = false,
-         trackNumber: Bool = false) {
-
+    init(_ criteria: [VLCMLSortingCriteria]) {
+        sortingCriteria = criteria
         currentSort = .default
         desc = false
-        // The first element of this array should always be VLCMLSortingCriteriaDefault
-        sortingCriteria = [false,
-                           alpha,
-                           duration,
-                           insertionDate,
-                           lastModificationDate,
-                           releaseDate,
-                           fileSize,
-                           artist,
-                           playCount,
-                           album,
-                           filename,
-                           trackNumber]
     }
 }
 

--- a/Sources/VLCActionSheet/VLCActionSheet.swift
+++ b/Sources/VLCActionSheet/VLCActionSheet.swift
@@ -20,7 +20,7 @@ import UIKit
 @objc protocol VLCActionSheetDelegate {
     @objc optional func headerViewTitle() -> String?
     @objc func itemAtIndexPath(_ indexPath: IndexPath) -> Any?
-    @objc func actionSheet(collectionView: UICollectionView, didSelectItem item: Any, At indexPath: IndexPath)
+    @objc optional func actionSheet(collectionView: UICollectionView, didSelectItem item: Any, At indexPath: IndexPath)
 }
 
 // MARK: VLCActionSheet
@@ -298,7 +298,7 @@ extension VLCActionSheet: UICollectionViewDelegateFlowLayout {
 extension VLCActionSheet: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let delegate = delegate, let item = delegate.itemAtIndexPath(indexPath) {
-            delegate.actionSheet(collectionView: collectionView, didSelectItem: item, At: indexPath)
+            delegate.actionSheet?(collectionView: collectionView, didSelectItem: item, At: indexPath)
             action?(item)
         }
         removeActionSheet()


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Use `VLCActionSheet` to display sort alert.

While integrating VLCActionSheet, I relealized that it would be simpler to pass an array of supported sorting criterias.

Indeed, this way we won't encounter index syncronization issues and it will make the global usage easier.

A follow-up ticket to this PR would be to polish it with the new design(adding icons that we currently don't have for every criteria).

Closes [#415](https://code.videolan.org/videolan/vlc-ios/issues/415).