### PR TITLE
VLCEditController: Move add to playlist logic into models

### DIFF
--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -70,11 +70,14 @@ extension AlbumModel {
 }
 
 // MARK: - Edit
+
 extension AlbumModel: EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type {
         return MediaEditCell.self
     }
 }
+
+// MARK: - MediaLibraryObserver
 
 extension AlbumModel: MediaLibraryObserver {
     func medialibrary(_ medialibrary: MediaLibraryService, didAddAlbums albums: [VLCMLAlbum]) {

--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -37,6 +37,26 @@ class AlbumModel: MLBaseModel {
     func delete(_ items: [VLCMLObject]) {
         preconditionFailure("AlbumModel: Cannot delete album")
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {
+        let playlist = medialibrary.createPlaylist(with: name)
+
+        guard let fileIndexes = fileIndexes else {
+            return
+        }
+
+        for index in fileIndexes  where index.row < files.count {
+            // Get all tracks from a VLCMLAlbum
+            guard let tracks = files[index.row].tracks(with: .default, desc: false) else {
+                assertionFailure("AlbumModel: createPlaylist: Fail to retreive tracks.")
+                return
+            }
+
+            tracks.forEach() {
+                playlist.appendMedia(withIdentifier: $0.identifier())
+            }
+        }
+    }
 }
 
 // MARK: - Sort

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -76,6 +76,8 @@ extension ArtistModel {
     }
 }
 
+// MARK: - MediaLibraryObserver
+
 extension ArtistModel: MediaLibraryObserver {
     func medialibrary(_ medialibrary: MediaLibraryService, didAddArtists artists: [VLCMLArtist]) {
         artists.forEach({ append($0) })

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -37,6 +37,27 @@ class ArtistModel: MLBaseModel {
     func delete(_ items: [VLCMLObject]) {
         preconditionFailure("ArtistModel: Cannot delete artist")
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {
+        let playlist = medialibrary.createPlaylist(with: name)
+
+        guard let fileIndexes = fileIndexes else {
+            return
+        }
+
+        for index in fileIndexes  where index.row < files.count {
+            // Get all tracks from a VLCMLArtist
+            guard let tracks = files[index.row].tracks(with: .default, desc: false) else {
+                assertionFailure("ArtistModel: createPlaylist: Fail to retreive tracks.")
+                return
+            }
+
+            tracks.forEach() {
+                playlist.appendMedia(withIdentifier: $0.identifier())
+            }
+        }
+    }
+
 }
 // MARK: - Edit
 extension ArtistModel: EditableMLModel {

--- a/SharedSources/MediaLibraryModel/AudioModel.swift
+++ b/SharedSources/MediaLibraryModel/AudioModel.swift
@@ -43,6 +43,7 @@ extension AudioModel {
 }
 
 // MARK: - Edit
+
 extension AudioModel: EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type {
         return MediaEditCell.self

--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -38,6 +38,10 @@ class CollectionModel: MLBaseModel {
     func delete(_ items: [VLCMLObject]) {
        assertionFailure("still needs implementation")
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>?) {
+        assertionFailure("still needs implementation")
+    }
 }
 
 // MARK: - Edit

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -37,6 +37,26 @@ class GenreModel: MLBaseModel {
     func delete(_ items: [VLCMLObject]) {
         preconditionFailure("GenreModel: Cannot delete genre")
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {
+        let playlist = medialibrary.createPlaylist(with: name)
+
+        guard let fileIndexes = fileIndexes else {
+            return
+        }
+
+        for index in fileIndexes  where index.row < files.count {
+            // Get all tracks from a VLCMLGenre
+            guard let tracks = files[index.row].tracks(with: .default, desc: false) else {
+                assertionFailure("GenreModel: createPlaylist: Fail to retreive tracks.")
+                return
+            }
+
+            tracks.forEach() {
+                playlist.appendMedia(withIdentifier: $0.identifier())
+            }
+        }
+    }
 }
 
 // MARK: - Sort

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -69,6 +69,8 @@ extension GenreModel {
     }
 }
 
+// MARK: - MediaLibraryObserver
+
 extension GenreModel: MediaLibraryObserver {
     func medialibrary(_ medialibrary: MediaLibraryService, didAddGenres genres: [VLCMLGenre]) {
         genres.forEach({ append($0) })
@@ -77,11 +79,15 @@ extension GenreModel: MediaLibraryObserver {
 }
 
 // MARK: - Edit
+
 extension GenreModel: EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type {
         return MediaEditCell.self
     }
 }
+
+// MARK: - Helpers
+
 extension VLCMLGenre {
     @objc func numberOfTracksString() -> String {
         let numberOftracks = numberOfTracks()

--- a/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
@@ -25,6 +25,7 @@ protocol MediaLibraryBaseModel {
     func append(_ item: VLCMLObject)
     func delete(_ items: [VLCMLObject])
     func sort(by criteria: VLCMLSortingCriteria)
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>?)
 }
 
 protocol MLBaseModel: AnyObject, MediaLibraryBaseModel {
@@ -44,6 +45,7 @@ protocol MLBaseModel: AnyObject, MediaLibraryBaseModel {
     // FIXME: Ideally items should be MLType but Swift isn't happy so it will always fail
     func delete(_ items: [VLCMLObject])
     func sort(by criteria: VLCMLSortingCriteria)
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>?)
 }
 
 extension MLBaseModel {

--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -43,7 +43,7 @@ extension MediaModel {
     }
 }
 
-// MARK: - VLCMLMedia
+// MARK: - Helpers
 
 extension VLCMLMedia {
     static func == (lhs: VLCMLMedia, rhs: VLCMLMedia) -> Bool {

--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -29,6 +29,18 @@ extension MediaModel {
             assertionFailure("MediaModel: Delete failed: \(error.localizedDescription)")
         }
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {
+        let playlist = medialibrary.createPlaylist(with: name)
+
+        guard let fileIndexes = fileIndexes else {
+            return
+        }
+
+        for index in fileIndexes  where index.row < files.count {
+            playlist.appendMedia(withIdentifier: files[index.row].identifier())
+        }
+    }
 }
 
 // MARK: - VLCMLMedia

--- a/SharedSources/MediaLibraryModel/PlaylistModel.swift
+++ b/SharedSources/MediaLibraryModel/PlaylistModel.swift
@@ -84,6 +84,8 @@ extension PlaylistModel {
     }
 }
 
+// MARK: - MediaLibraryObserver
+
 extension PlaylistModel: MediaLibraryObserver {
     func medialibrary(_ medialibrary: MediaLibraryService, didAddPlaylists playlists: [VLCMLPlaylist]) {
         playlists.forEach({ append($0) })
@@ -100,6 +102,8 @@ extension PlaylistModel: MediaLibraryObserver {
         updateView?()
     }
 }
+
+// MARK: - Helpers
 
 extension VLCMLPlaylist {
     func description() -> String {

--- a/SharedSources/MediaLibraryModel/PlaylistModel.swift
+++ b/SharedSources/MediaLibraryModel/PlaylistModel.swift
@@ -52,6 +52,26 @@ class PlaylistModel: MLBaseModel {
         append(medialibrary.createPlaylist(with: name))
         updateView?()
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {
+        let playlist = medialibrary.createPlaylist(with: name)
+
+        guard let fileIndexes = fileIndexes else {
+            return
+        }
+
+        for index in fileIndexes  where index.row < files.count {
+            // Get all tracks from a VLCMLPlaylist
+            guard let media = files[index.row].media else {
+                assertionFailure("PlaylistModel: createPlaylist: Failed to retreive media.")
+                return
+            }
+
+            media.forEach() {
+                playlist.appendMedia(withIdentifier: $0.identifier())
+            }
+        }
+    }
 }
 
 // MARK: - Sort

--- a/SharedSources/MediaLibraryModel/ShowEpisodeModel.swift
+++ b/SharedSources/MediaLibraryModel/ShowEpisodeModel.swift
@@ -50,6 +50,8 @@ extension ShowEpisodeModel {
     }
 }
 
+// MARK: - MediaLibraryObserver
+
 extension ShowEpisodeModel: MediaLibraryObserver {
     func medialibrary(_ medialibrary: MediaLibraryService, didAddShowEpisodes showEpisodes: [VLCMLMedia]) {
         showEpisodes.forEach({ append($0) })

--- a/SharedSources/MediaLibraryModel/ShowEpisodeModel.swift
+++ b/SharedSources/MediaLibraryModel/ShowEpisodeModel.swift
@@ -36,6 +36,10 @@ class ShowEpisodeModel: MLBaseModel {
     func delete(_ items: [VLCMLObject]) {
         preconditionFailure("ShowEpisodeModel: Cannot delete showEpisode")
     }
+
+    func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {
+        assertionFailure("ShowEpisodeModel: createPlaylist: Not integrated.")
+    }
 }
 
 // MARK: - Sort

--- a/SharedSources/MediaLibraryModel/VideoModel.swift
+++ b/SharedSources/MediaLibraryModel/VideoModel.swift
@@ -33,6 +33,7 @@ class VideoModel: MediaModel {
 }
 
 // MARK: - Edit
+
 extension VideoModel: EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type {
         return MediaEditCell.self
@@ -66,11 +67,9 @@ extension VideoModel: MediaLibraryObserver {
         }
         updateView?()
     }
-}
 
-// MARK: MediaLibraryObserver - Thumbnail
+    // MARK: - Thumbnail
 
-extension VideoModel {
     func medialibrary(_ medialibrary: MediaLibraryService, thumbnailReady media: VLCMLMedia) {
         for (index, file) in files.enumerated() {
             if file == media {
@@ -81,4 +80,3 @@ extension VideoModel {
         updateView?()
     }
 }
-

--- a/SharedSources/MediaLibraryModel/VideoModel.swift
+++ b/SharedSources/MediaLibraryModel/VideoModel.swift
@@ -71,11 +71,9 @@ extension VideoModel: MediaLibraryObserver {
     // MARK: - Thumbnail
 
     func medialibrary(_ medialibrary: MediaLibraryService, thumbnailReady media: VLCMLMedia) {
-        for (index, file) in files.enumerated() {
-            if file == media {
-                files[index] = media
-                break
-            }
+        for (index, file) in files.enumerated() where file == media {
+            files[index] = media
+            break
         }
         updateView?()
     }

--- a/Sources/VLCEditController.swift
+++ b/Sources/VLCEditController.swift
@@ -93,27 +93,21 @@ private extension VLCEditController {
 // MARK: - VLCEditToolbarDelegate
 
 extension VLCEditController: VLCEditToolbarDelegate {
-
     func editToolbarDidAddToPlaylist(_ editToolbar: VLCEditToolbar) {
-        //Todo: replace with Viewcontroller that shows existing Playlists
         let alertInfo = TextFieldAlertInfo(alertTitle: NSLocalizedString("PLAYLISTS", comment: ""),
-                                           alertDescription: NSLocalizedString("PLAYLIST_DESCRIPTION", comment: ""),
-                                           placeHolder: NSLocalizedString("PLAYLIST_PLACEHOLDER", comment:""))
-
+                                           placeHolder: "NEW_PLAYLIST")
         presentTextFieldAlert(with: alertInfo, completionHandler: {
-            [weak self] text -> Void in
-            guard let strongSelf = self else {
+            [unowned self] text -> Void in
+            guard text != "" else {
+                DispatchQueue.main.async {
+                    VLCAlertViewController.alertViewManager(title: NSLocalizedString("ERROR_EMPTY_NAME",
+                                                                                     comment: ""),
+                                                            viewController: self)
+                }
                 return
             }
-            let playlist = strongSelf.mediaLibraryService.createPlaylist(with: text)
-
-            for indexPath in strongSelf.selectedCellIndexPaths {
-                guard let media = strongSelf.model.anyfiles[indexPath.row] as? VLCMLMedia else {
-                    assertionFailure("we're not handling collections yet")
-                    return
-                }
-                playlist.appendMedia(withIdentifier: media.identifier())
-            }
+            self.model.createPlaylist(text, self.selectedCellIndexPaths)
+            self.selectedCellIndexPaths.removeAll()
         })
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This PR moves the add to playlist logic during the edit into the models.
This allows to have specific actions for different models.

Additionally, this integration only creates new playlist with a selection.
The ability to add to existing playlists will be added later on with the UI.