### PR TITLE
AppCoordinator: Dismiss directly migrationViewController

### DIFF
--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -70,11 +70,9 @@ extension AppCoordinator: MediaLibraryMigrationDelegate {
     }
 
     func medialibraryDidFinishMigration(_ medialibrary: MediaLibraryService) {
-        if tabBarController.presentedViewController === migrationViewController {
-            DispatchQueue.main.async {
-                [tabBarController] in
-                tabBarController.dismiss(animated: true, completion: nil)
-            }
+        DispatchQueue.main.async {
+            [migrationViewController] in
+            migrationViewController.dismiss(animated: true, completion: nil)
         }
     }
 


### PR DESCRIPTION
In the case of a fresh install of the app or even an empty or small
library, the tabBarController didn't have the time to finish to present
the VC therefore failing the check in `medialibraryDidFinishMigration`.

Removing the migrationViewController directly resolve this issue.

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

In the case of a fresh install of the app or even an empty or small library, the tabBarController didn't have the time to finish to present the VC, therefore, failing the check in `medialibraryDidFinishMigration`.

Removing the migrationViewController directly resolve this issue.
