### PR TITLE
424 - Local Network Connect - Username field is not lowercased

### DIFF
--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginDataSourceLogin.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginDataSourceLogin.m
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSUInteger, VLCNetworkServerLoginIndex) {
     NSString *labelString = nil;
     NSString *valueString = nil;
     UIReturnKeyType returnKeyType = UIReturnKeyNext;
+    UITextAutocapitalizationType autocapitalizationType = UITextAutocapitalizationTypeSentences;
     switch (row) {
         case VLCNetworkServerLoginIndexServer:
             keyboardType = UIKeyboardTypeURL;
@@ -81,6 +82,7 @@ typedef NS_ENUM(NSUInteger, VLCNetworkServerLoginIndex) {
             break;
         case VLCNetworkServerLoginIndexUsername:
             labelString = NSLocalizedString(@"USER_LABEL", nil);
+            autocapitalizationType = UITextAutocapitalizationTypeNone;
             valueString = self.loginInformation.username;
             break;
         case VLCNetworkServerLoginIndexPassword:
@@ -107,6 +109,7 @@ typedef NS_ENUM(NSUInteger, VLCNetworkServerLoginIndex) {
 
     fieldCell.placeholderString = labelString;
     UITextField *textField = fieldCell.textField;
+    textField.autocapitalizationType = autocapitalizationType;
     textField.text              = valueString;
     textField.keyboardType      = keyboardType;
     textField.secureTextEntry   = secureTextEntry;


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This PR is to resolve https://code.videolan.org/videolan/vlc-ios/issues/424.
- Create a local variable to store the UITextFIeld's autocapitalizationType, and set the value to UITextAutocapitalizationTypeSentences (which is the OS default).
- For the username field, set the autoCapitalizationType to UITextAutocapitalizationTypeNone.
- Set UITextField’s autoCapitalizationType to the variable’s value.

Note that the autoCapitalizationType has no effect with certain keyboard types (such as numberPad or URL), or when secureTextEntry is YES.  These fields were always ignoring the default value of UITextAutocapitalizationTypeSentences, thus there’s no impact to explicitly setting them to this value here.