### PR TITLE
VLCServerListTVViewController: Add port textfield in server connections

### DIFF
--- a/Apple-TV/VLCServerListTVViewController.m
+++ b/Apple-TV/VLCServerListTVViewController.m
@@ -236,6 +236,8 @@
 
     __block UITextField *usernameField = nil;
     __block UITextField *passwordField = nil;
+    __block UITextField *portField = nil;
+
     [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
         textField.placeholder = NSLocalizedString(@"USER_LABEL", nil);
         textField.text = login.username;
@@ -246,6 +248,12 @@
         textField.placeholder = NSLocalizedString(@"PASSWORD_LABEL", nil);
         textField.text = login.password;
         passwordField = textField;
+    }];
+    [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = NSLocalizedString(@"SERVER_PORT", nil);
+        textField.keyboardType = UIKeyboardTypeNumberPad;
+        textField.text = login.port.stringValue;
+        portField = textField;
     }];
 
     NSMutableDictionary *additionalFieldsDict = [NSMutableDictionary dictionaryWithCapacity:login.additionalFields.count];
@@ -269,6 +277,7 @@
     void(^loginBlock)(BOOL) = ^(BOOL save) {
         login.username = usernameField.text;
         login.password = passwordField.text;
+        login.port = [NSNumber numberWithInt:portField.text.intValue];
         for (VLCNetworkServerLoginInformationField *fieldInfo in login.additionalFields) {
             UITextField *textField = additionalFieldsDict[fieldInfo.identifier];
             fieldInfo.textValue = textField.text;


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This is a quick fix/additions to add a port textfield when connecting to a discovered server.
I'm not sure if this is really needed but, it could be interesting to have for consistency with iOS.

Later on, it could be interesting to refactor this part of the code as well.

Preview:

![imagy](https://i.gyazo.com/60403927f23530fdee099e30215a7e1f.png)
