### PR TITLE
Fix celllayout: More dynamic cellsizes

### DIFF
--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -136,7 +136,9 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
     // MARK: Renderer
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
         collectionView?.collectionViewLayout.invalidateLayout()
+        cachedCellSize = .zero
     }
 
     // MARK: - Edit
@@ -220,21 +222,25 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
 extension VLCMediaCategoryViewController {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if cachedCellSize == .zero {
-            cachedCellSize = model.cellType.cellSizeForWidth(collectionView.frame.size.width)
+            if #available(iOS 11.0, *) {
+                cachedCellSize = model.cellType.cellSizeForWidth(collectionView.safeAreaLayoutGuide.layoutFrame.width)
+            } else {
+                cachedCellSize = model.cellType.cellSizeForWidth(collectionView.frame.size.width)
+            }
         }
         return cachedCellSize
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: model.cellType.cellPadding, left: model.cellType.cellPadding, bottom: model.cellType.cellPadding, right: model.cellType.cellPadding)
+        return UIEdgeInsets(top: model.cellType.edgePadding, left: model.cellType.edgePadding, bottom: model.cellType.edgePadding, right: model.cellType.edgePadding)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return model.cellType.cellPadding
+        return model.cellType.edgePadding
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return model.cellType.cellPadding
+        return model.cellType.interItemPadding
     }
 
     override func handleSort() {

--- a/Sources/MediaCategoryCells/ArtistCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/ArtistCollectionViewCell.swift
@@ -16,9 +16,6 @@ class ArtistCollectionViewCell: BaseCollectionViewCell {
 
     @IBOutlet weak var thumbnailView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
-    override class var cellPadding: CGFloat {
-        return 5.0
-    }
 
     override var media: VLCMLObject? {
         didSet {
@@ -49,13 +46,25 @@ class ArtistCollectionViewCell: BaseCollectionViewCell {
     }
 
     override class func cellSizeForWidth(_ width: CGFloat) -> CGSize {
-        let numberOfCells: CGFloat = round(width / 320)
+        let numberOfCells: CGFloat
+        if width <= 414 { //max iPhone portrait width
+            numberOfCells = 1
+        } else if width <= 896 { // max landscape iPhone width includes small iPads in protrait
+            numberOfCells = 2
+        } else if width <= 1024 { // max landscape for small iPads
+            numberOfCells = 3
+        } else { //ipad Pro in Landscape
+            numberOfCells = 4
+        }
 
-        // We have the number of cells and we always have numberofCells + 1 padding spaces. -pad-[Cell]-pad-[Cell]-pad-
-        // we then have the entire padding, we divide the entire padding by the number of Cells to know how much needs to be substracted from ech cell
-        // since this might be an uneven number we ceil
-        var cellWidth = width / numberOfCells
-        cellWidth = cellWidth - ceil(((numberOfCells + 1) * cellPadding) / numberOfCells)
+        // We have the number of cells and we always have numberofCells + 1 interItemPadding spaces.
+        //
+        // edgePadding-interItemPadding-[Cell]-interItemPadding-[Cell]-interItemPadding-edgePadding
+        //
+
+        let overallWidth = width - (2 * edgePadding)
+        let overallCellWidthWithoutPadding = overallWidth - (numberOfCells + 1) * interItemPadding
+        let cellWidth = floor(overallCellWidthWithoutPadding / numberOfCells)
 
         return CGSize(width: cellWidth, height: 80)
     }

--- a/Sources/MediaCategoryCells/AudioCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/AudioCollectionViewCell.swift
@@ -18,9 +18,6 @@ class AudioCollectionViewCell: BaseCollectionViewCell {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var newLabel: UILabel!
-    override class var cellPadding: CGFloat {
-        return 5.0
-    }
 
     override var media: VLCMLObject? {
         didSet {
@@ -64,13 +61,25 @@ class AudioCollectionViewCell: BaseCollectionViewCell {
     }
 
     override class func cellSizeForWidth(_ width: CGFloat) -> CGSize {
-        let numberOfCells: CGFloat = round(width / 320)
+        let numberOfCells: CGFloat
+        if width <= 414 { //max iPhone portrait width
+            numberOfCells = 1
+        } else if width <= 896 { // max landscape iPhone width includes small iPads in protrait
+            numberOfCells = 2
+        } else if width <= 1024 { // max landscape for small iPads
+            numberOfCells = 3
+        } else { //ipad Pro in Landscape
+            numberOfCells = 4
+        }
 
-        // We have the number of cells and we always have numberofCells + 1 padding spaces. -pad-[Cell]-pad-[Cell]-pad-
-        // we then have the entire padding, we divide the entire padding by the number of Cells to know how much needs to be substracted from ech cell
-        // since this might be an uneven number we ceil
-        var cellWidth = width / numberOfCells
-        cellWidth = cellWidth - ceil(((numberOfCells + 1) * cellPadding) / numberOfCells)
+        // We have the number of cells and we always have numberofCells + 1 interItemPadding spaces.
+        //
+        // edgePadding-interItemPadding-[Cell]-interItemPadding-[Cell]-interItemPadding-edgePadding
+        //
+
+        let overallWidth = width - (2 * edgePadding)
+        let overallCellWidthWithoutPadding = overallWidth - (numberOfCells + 1) * interItemPadding
+        let cellWidth = floor(overallCellWidthWithoutPadding / numberOfCells)
 
         return CGSize(width: cellWidth, height: 80)
     }

--- a/Sources/MediaCategoryCells/BaseCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/BaseCollectionViewCell.swift
@@ -28,7 +28,11 @@ class BaseCollectionViewCell: UICollectionViewCell {
         return CGSize.zero
     }
 
-    class var cellPadding: CGFloat {
-        return 0
+    class var edgePadding: CGFloat {
+        return 15
+    }
+
+    class var interItemPadding: CGFloat {
+        return 5
     }
 }

--- a/Sources/MediaCategoryCells/MovieCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MovieCollectionViewCell.swift
@@ -21,8 +21,11 @@ class MovieCollectionViewCell: BaseCollectionViewCell {
     @IBOutlet weak var progressView: UIProgressView!
     @IBOutlet weak var collectionOverlay: UIView!
     @IBOutlet weak var numberOfTracks: UILabel!
-    override class var cellPadding: CGFloat {
-        return 5.0
+    override class var edgePadding: CGFloat {
+        return 12.5
+    }
+    override class var interItemPadding: CGFloat {
+        return 7.5
     }
 
     override var media: VLCMLObject? {
@@ -71,14 +74,26 @@ class MovieCollectionViewCell: BaseCollectionViewCell {
     }
 
     override class func cellSizeForWidth(_ width: CGFloat) -> CGSize {
-        let numberOfCells: CGFloat = round(width / 250)
+        let numberOfCells: CGFloat
+        if width <= 414 { //max iPhone portrait width
+            numberOfCells = 2
+        } else if width <= 896 { // max landscape iPhone width includes small iPads in protrait
+            numberOfCells = 3
+        } else if width <= 1024 { // max landscape for small iPads
+            numberOfCells = 4
+        } else { //ipad Pro in Landscape
+            numberOfCells = 5
+        }
         let aspectRatio: CGFloat = 10.0 / 16.0
 
-        // We have the number of cells and we always have numberofCells + 1 padding spaces. -pad-[Cell]-pad-[Cell]-pad-
-        // we then have the entire padding, we divide the entire padding by the number of Cells to know how much needs to be substracted from ech cell
-        // since this might be an uneven number we ceil
-        var cellWidth = width / numberOfCells
-        cellWidth = cellWidth - ceil(((numberOfCells + 1) * cellPadding) / numberOfCells)
+        // We have the number of cells and we always have numberofCells + 1 interItemPadding spaces.
+        //
+        // edgePadding-interItemPadding-[Cell]-interItemPadding-[Cell]-interItemPadding-edgePadding
+        //
+
+        let overallWidth = width - (2 * edgePadding)
+        let overallCellWidthWithoutPadding = overallWidth - (numberOfCells + 1) * interItemPadding
+        let cellWidth = floor(overallCellWidthWithoutPadding / numberOfCells)
 
         // 3*20 for the labels + 24 for 3*8 which is the padding
         return CGSize(width: cellWidth, height: cellWidth * aspectRatio + 3*20+24)


### PR DESCRIPTION
We define an overall number of items based on the width.
We also have independent edgespacing and interitempadding closes #315

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Dynamically shows between 2 and 5 movie cells, takes the safe area into consideration,
For movie cells it's 13.5 edge and between cell 7.5
For audio it's 1 to 4 cells  and edge 15 and between cell 5 

![Simulator Screen Shot - iPhone X - 2019-04-01 at 16 39 06](https://user-images.githubusercontent.com/2445653/55302538-0495c180-549e-11e9-8f9e-0d24f11625d3.png)

Takes into consideration the notch: 

![Simulator Screen Shot - iPhone X - 2019-04-01 at 16 39 02](https://user-images.githubusercontent.com/2445653/55302541-06f81b80-549e-11e9-801b-3693aadb7f9c.png)

![Simulator Screen Shot - iPad Pro (12 9-inch) (2nd generation) - 2019-04-01 at 16 54 39](https://user-images.githubusercontent.com/2445653/55302720-f09e8f80-549e-11e9-97cd-89f9a6013255.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) (2nd generation) - 2019-04-01 at 16 53 48](https://user-images.githubusercontent.com/2445653/55302743-0dd35e00-549f-11e9-8589-19ad83fcf4c9.png)
