### PR TITLE
MediaLibraryService: Migration: Update didMigrate value

### DIFF
--- a/SharedSources/MediaLibraryService.swift
+++ b/SharedSources/MediaLibraryService.swift
@@ -233,6 +233,7 @@ private extension MediaLibraryService {
 
         if migrateMedia(oldMedialibrary) && migratePlaylists(oldMedialibrary) {
             UserDefaults.standard.set(true, forKey: MediaLibraryService.migrationKey)
+            didMigrate = true
             return true
         }
         return false


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
By caching it on the start on the medialibrary, we need to update the value when successfully migrated, else it will continue to migrate on each new media parsing.
