### PR TITLE
bump deployment target to iOS 10

### DIFF
--- a/SharedSources/VLCMetadata.m
+++ b/SharedSources/VLCMetadata.m
@@ -155,7 +155,9 @@
 
 #if TARGET_OS_IOS
     if (self.artworkImage) {
-        MPMediaItemArtwork *mpartwork = [[MPMediaItemArtwork alloc] initWithImage:self.artworkImage];
+        MPMediaItemArtwork *mpartwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:self.artworkImage.size requestHandler:^UIImage * _Nonnull(CGSize size) {
+            return self.artworkImage;
+        }];
         currentlyPlayingTrackInfo[MPMediaItemPropertyArtwork] = mpartwork;
     }
 #endif

--- a/Sources/VLCAboutViewController.m
+++ b/Sources/VLCAboutViewController.m
@@ -109,10 +109,12 @@
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
 {
     NSURL *requestURL = request.URL;
-    if (![requestURL.scheme isEqualToString:@""])
-        return ![[UIApplication sharedApplication] openURL:requestURL];
-    else
+    if (![requestURL.scheme isEqualToString:@""] && [[UIApplication sharedApplication] canOpenURL:requestURL]) {
+        [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:nil];
+        return NO;
+    } else {
         return YES;
+    }
 }
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView
@@ -123,7 +125,7 @@
 
 - (IBAction)openContributePage:(id)sender
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.videolan.org/contribute.html"]];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.videolan.org/contribute.html"] options:@{} completionHandler:nil];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle

--- a/Sources/VLCBugreporter.m
+++ b/Sources/VLCBugreporter.m
@@ -41,7 +41,7 @@
                                                  [[VLCAlertButton alloc] initWithTitle:NSLocalizedString(@"BUG_REPORT_BUTTON", nil)
                                                                                 action: ^(UIAlertAction *action) {
                                                                                     NSURL *url = [NSURL URLWithString:@"https://trac.videolan.org/vlc/newticket"];
-                                                                                    [[UIApplication sharedApplication] openURL:url];
+                                                                                    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
                                                                                 }]
                                                  
                                                  ];

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -142,7 +142,7 @@
         [DBClientsManager authorizeFromController:[UIApplication sharedApplication]
                                        controller:self
                                           openURL:^(NSURL *url) {
-                                              [[UIApplication sharedApplication] openURL:url];
+                                              [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
                                           }];
     } else
         [_dropboxController logout];

--- a/Sources/VLCFirstStepsSixthPageViewController.m
+++ b/Sources/VLCFirstStepsSixthPageViewController.m
@@ -42,7 +42,7 @@
 
 - (IBAction)learnMore:(id)sender
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.videolan.org/contribute.html"]];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.videolan.org/contribute.html"] options:@{} completionHandler:nil];
 }
 
 @end

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -3711,7 +3711,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sources/VLC for iOS-Prefix.pch";
 				INFOPLIST_FILE = "Sources/VLC for iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -3753,7 +3753,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sources/VLC for iOS-Prefix.pch";
 				INFOPLIST_FILE = "Sources/VLC for iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
@@ -3845,7 +3845,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sources/VLC for iOS-Prefix.pch";
 				INFOPLIST_FILE = "Sources/VLC for iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
this drops support for iPhone 4s, original iPad mini and iPads older than the iPad 4. 2016
would close #273 & #274 