### PR TITLE
Play all items of a collection

### DIFF
--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class CollectionModel: MLBaseModel {
     var sortModel: SortModel
+    var mediaCollection: MediaCollectionModel
 
     typealias MLType = VLCMLMedia // could be anything
     required init(medialibrary: MediaLibraryService) {
@@ -18,6 +19,7 @@ class CollectionModel: MLBaseModel {
 
     required init(mediaService: MediaLibraryService, mediaCollection: MediaCollectionModel) {
         self.medialibrary = mediaService
+        self.mediaCollection = mediaCollection
         files = mediaCollection.files()
         sortModel = mediaCollection.sortModel() ?? SortModel([.default])
     }

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -362,7 +362,14 @@ extension VLCMediaCategoryViewController {
 
     func play(media: VLCMLMedia) {
         VLCPlaybackController.sharedInstance().fullscreenSessionRequested = media.subtype() != .albumTrack
-        VLCPlaybackController.sharedInstance().play(media)
+        if let collectionModel = model as? CollectionModel, collectionModel.mediaCollection is VLCMLPlaylist || collectionModel.mediaCollection is VLCMLAlbum {
+            guard let index = collectionModel.files.index(of: media) else {
+                return
+            }
+            VLCPlaybackController.sharedInstance().playMedia(at: index, fromCollection: collectionModel.files)
+        } else {
+            VLCPlaybackController.sharedInstance().play(media)
+        }
     }
 }
 

--- a/Sources/VLCPlaybackController+MediaLibrary.h
+++ b/Sources/VLCPlaybackController+MediaLibrary.h
@@ -17,5 +17,6 @@
 @interface VLCPlaybackController (MediaLibrary)
 - (void)playMediaLibraryObject:(NSManagedObject *)mediaObject;
 - (void)playMedia:(VLCMLMedia *)media;
+- (void)playMediaAtIndex:(NSInteger)index fromCollection:(NSArray<VLCMLMedia *> *)collection;
 - (void)openMediaLibraryObject:(NSManagedObject *)mediaObject;
 @end

--- a/Sources/VLCPlaybackController+MediaLibrary.m
+++ b/Sources/VLCPlaybackController+MediaLibrary.m
@@ -38,6 +38,11 @@
         [self configureWithShowEpisode:(MLShowEpisode *)mediaObject];
 }
 
+- (void)playMediaAtIndex:(NSInteger)index fromCollection:(NSArray<VLCMLMedia *> *)collection
+{
+    [self configureMediaListWithMLMedia:collection indexToPlay:(int) index];
+}
+
 - (void)playMedia:(VLCMLMedia *)media
 {
     [self configureMediaListWithMLMedia:@[media] indexToPlay:0];
@@ -138,6 +143,7 @@ Open a file in the libraryViewController without changing the playstate
 }
 
 - (void)configureMediaListWithMLMedia:(NSArray<VLCMLMedia *> *)mlMedia indexToPlay:(int)index {
+    NSAssert(index >= 0, @"The index should never be negative");
     VLCMediaList *list = [[VLCMediaList alloc] init];
     VLCMedia *media;
     for (VLCMLMedia *file in mlMedia) {


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
before we just played one file, now it plays an entire collection no matter if it's a playlist or album.
I left the collectionsmodel commit in so that you can sync an album and try it out :) 
I know that this also plays all items of an artist or genre but I think it's okay. I actually even pondered if we shouldn't in general play all items in a viewcontroller.