### PR TITLE
MediaCollectionViewCell: Adapt to configure also for movies in playlists

### DIFF
--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -18,7 +18,7 @@ class AlbumModel: MLBaseModel {
 
     var files = [VLCMLAlbum]()
 
-    var cellType: BaseCollectionViewCell.Type { return AudioCollectionViewCell.self }
+    var cellType: BaseCollectionViewCell.Type { return MediaCollectionViewCell.self }
 
     var medialibrary: MediaLibraryService
 

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -18,7 +18,7 @@ class ArtistModel: MLBaseModel {
 
     var files = [VLCMLArtist]()
 
-    var cellType: BaseCollectionViewCell.Type { return AudioCollectionViewCell.self }
+    var cellType: BaseCollectionViewCell.Type { return MediaCollectionViewCell.self }
 
     var medialibrary: MediaLibraryService
 

--- a/SharedSources/MediaLibraryModel/AudioModel.swift
+++ b/SharedSources/MediaLibraryModel/AudioModel.swift
@@ -18,7 +18,7 @@ class AudioModel: MediaModel {
 
     var files = [VLCMLMedia]()
 
-    var cellType: BaseCollectionViewCell.Type { return AudioCollectionViewCell.self }
+    var cellType: BaseCollectionViewCell.Type { return MediaCollectionViewCell.self }
 
     var medialibrary: MediaLibraryService
 

--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -31,7 +31,7 @@ class CollectionModel: MLBaseModel {
 
     var files = [VLCMLMedia]()
 
-    var cellType: BaseCollectionViewCell.Type { return AudioCollectionViewCell.self } //TODO: this approach will not work here because playlists can contain audio or videocells
+    var cellType: BaseCollectionViewCell.Type { return MediaCollectionViewCell.self }
 
     var indicatorName: String = NSLocalizedString("Collections", comment: "")
 

--- a/Sources/MediaCategoryCells/AudioCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/AudioCollectionViewCell.swift
@@ -21,12 +21,14 @@ class AudioCollectionViewCell: BaseCollectionViewCell {
 
     override var media: VLCMLObject? {
         didSet {
-            if let albumTrack = media as? VLCMLMedia {
+            if let albumTrack = media as? VLCMLMedia, albumTrack.subtype() == .albumTrack {
                 update(audiotrack:albumTrack)
             } else if let album = media as? VLCMLAlbum {
                 update(album:album)
             } else if let artist = media as? VLCMLArtist {
                 update(artist:artist)
+            } else if let movie = media as? VLCMLMedia, movie.subtype() == .unknown {
+                update(movie:movie)
             } else {
                 fatalError("needs to be of Type VLCMLMedia or VLCMLAlbum")
             }
@@ -66,6 +68,15 @@ class AudioCollectionViewCell: BaseCollectionViewCell {
         thumbnailView.layer.cornerRadius = thumbnailView.frame.size.width / 2.0
         titleLabel.text = artist.name
         descriptionLabel.text = artist.numberOfTracksString()
+    }
+
+    func update(movie: VLCMLMedia) {
+        titleLabel.text = movie.title
+        descriptionLabel.text = movie.mediaDuration()
+        if movie.isThumbnailGenerated() {
+            thumbnailView.image = UIImage(contentsOfFile: movie.thumbnail.absoluteString)
+        }
+        newLabel.isHidden = !movie.isNew()
     }
 
     override class func cellSizeForWidth(_ width: CGFloat) -> CGSize {

--- a/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * AudioCollectionViewCell.swift
+ * MediaCollectionViewCell.swift
  * VLC for iOS
  *****************************************************************************
  * Copyright (c) 2018 VideoLAN. All rights reserved.
@@ -12,7 +12,7 @@
 
 import Foundation
 
-class AudioCollectionViewCell: BaseCollectionViewCell {
+class MediaCollectionViewCell: BaseCollectionViewCell {
 
     @IBOutlet weak var thumbnailView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!

--- a/Sources/MediaCategoryCells/MediaCollectionViewCell.xib
+++ b/Sources/MediaCategoryCells/MediaCollectionViewCell.xib
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="OaX-w0-CLr" userLabel="Audio Collection View Cell" customClass="AudioCollectionViewCell" customModule="VLC" customModuleProvider="target">
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="OaX-w0-CLr" userLabel="MediaCollectionViewCell" customClass="MediaCollectionViewCell" customModule="VLC" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="480" height="80"/>
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -42,8 +42,8 @@
 		417E68B91F321EFF00DB9BB2 /* VLCActivityViewControllerVendor.m in Sources */ = {isa = PBXBuildFile; fileRef = 417E68B81F321EFF00DB9BB2 /* VLCActivityViewControllerVendor.m */; };
 		4181087A2142894A0046A931 /* PlayingExternallyView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 418108792142894A0046A931 /* PlayingExternallyView.xib */; };
 		4184AA151A5492070063DF5A /* VLCCloudStorageController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4184AA141A5492070063DF5A /* VLCCloudStorageController.m */; };
-		41884A4E214BE0C800D2C6B4 /* AudioCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41884A4D214BE0C800D2C6B4 /* AudioCollectionViewCell.xib */; };
-		41884A50214BE0D800D2C6B4 /* AudioCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41884A4F214BE0D800D2C6B4 /* AudioCollectionViewCell.swift */; };
+		41884A4E214BE0C800D2C6B4 /* MediaCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41884A4D214BE0C800D2C6B4 /* MediaCollectionViewCell.xib */; };
+		41884A50214BE0D800D2C6B4 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41884A4F214BE0D800D2C6B4 /* MediaCollectionViewCell.swift */; };
 		418B144720179C00000447AA /* MediaCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418B144620179C00000447AA /* MediaCategoryViewController.swift */; };
 		418B144D20179C75000447AA /* VLCTabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418B144C20179C74000447AA /* VLCTabBarCoordinator.swift */; };
 		418B145020179CB9000447AA /* LayoutAnchorContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418B144F20179CB9000447AA /* LayoutAnchorContainer.swift */; };
@@ -503,8 +503,8 @@
 		418108792142894A0046A931 /* PlayingExternallyView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = PlayingExternallyView.xib; path = Resources/PlayingExternallyView.xib; sourceTree = "<group>"; };
 		4184AA131A5492070063DF5A /* VLCCloudStorageController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VLCCloudStorageController.h; path = Sources/VLCCloudStorageController.h; sourceTree = SOURCE_ROOT; };
 		4184AA141A5492070063DF5A /* VLCCloudStorageController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VLCCloudStorageController.m; path = Sources/VLCCloudStorageController.m; sourceTree = SOURCE_ROOT; };
-		41884A4D214BE0C800D2C6B4 /* AudioCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AudioCollectionViewCell.xib; sourceTree = "<group>"; };
-		41884A4F214BE0D800D2C6B4 /* AudioCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCollectionViewCell.swift; sourceTree = "<group>"; };
+		41884A4D214BE0C800D2C6B4 /* MediaCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MediaCollectionViewCell.xib; sourceTree = "<group>"; };
+		41884A4F214BE0D800D2C6B4 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
 		418B144620179C00000447AA /* MediaCategoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaCategoryViewController.swift; path = Sources/MediaCategories/MediaCategoryViewController.swift; sourceTree = SOURCE_ROOT; };
 		418B144C20179C74000447AA /* VLCTabBarCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VLCTabBarCoordinator.swift; path = Sources/VLCTabBarCoordinator.swift; sourceTree = SOURCE_ROOT; };
 		418B144F20179CB9000447AA /* LayoutAnchorContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LayoutAnchorContainer.swift; path = Sources/LayoutAnchorContainer.swift; sourceTree = "<group>"; };
@@ -1146,8 +1146,8 @@
 				41EC28E22136D905004BCF0F /* BaseCollectionViewCell.swift */,
 				41EC28E42136DD41004BCF0F /* MovieCollectionViewCell.swift */,
 				41EC28E82136DE46004BCF0F /* MovieCollectionViewCell.xib */,
-				41884A4F214BE0D800D2C6B4 /* AudioCollectionViewCell.swift */,
-				41884A4D214BE0C800D2C6B4 /* AudioCollectionViewCell.xib */,
+				41884A4F214BE0D800D2C6B4 /* MediaCollectionViewCell.swift */,
+				41884A4D214BE0C800D2C6B4 /* MediaCollectionViewCell.xib */,
 				41CF03E721D117D100B449E0 /* GenreCollectionViewCell.swift */,
 				41CF03E921D1181100B449E0 /* GenreCollectionViewCell.xib */,
 			);
@@ -2562,7 +2562,7 @@
 				7D27EC2B19DF310300EF0370 /* VLCFirstStepsSecondPageViewController~ipad.xib in Resources */,
 				417CDA241A48D1F300D9ACE7 /* VLCCloudServicesTableViewController.xib in Resources */,
 				7D9870671A3E03D5009CF27D /* papasscode_failed_bg@2x.png in Resources */,
-				41884A4E214BE0C800D2C6B4 /* AudioCollectionViewCell.xib in Resources */,
+				41884A4E214BE0C800D2C6B4 /* MediaCollectionViewCell.xib in Resources */,
 				41CF03EA21D1181100B449E0 /* GenreCollectionViewCell.xib in Resources */,
 				7DDFF4251BDFD23300913BD1 /* VLCCone512x512.png in Resources */,
 				7DF04F4F1961F2B8004A5429 /* web-open-fixed.png in Resources */,
@@ -2937,7 +2937,7 @@
 				DD3EFF331BDEBCE500B68579 /* VLCLocalNetworkServiceBrowserMediaDiscoverer.m in Sources */,
 				7DE56C1A1AD93F9100E8CA00 /* VLCPlaybackController.m in Sources */,
 				4152F1621FEF19BD00F1908B /* KeychainCoordinator.swift in Sources */,
-				41884A50214BE0D800D2C6B4 /* AudioCollectionViewCell.swift in Sources */,
+				41884A50214BE0D800D2C6B4 /* MediaCollectionViewCell.swift in Sources */,
 				DD7110F01AF38B2B00854776 /* MLMediaLibrary+playlist.m in Sources */,
 				7D5CAA891A4AD763003F2CBC /* VLCTrackSelectorTableViewCell.m in Sources */,
 				7D63C19018774B1700BD5256 /* VLCFirstStepsSecondPageViewController.m in Sources */,


### PR DESCRIPTION
closes #439

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

The design for a movie in a playlist still needs to be consistent and different from the one in the movietab, which is why we reuse the AudioCollectionCell here. Ideally we rename it to reflect the versatility of this class 