### PR TITLE
Equalizer: Add off state and set the equalizer to disabled by default

### DIFF
--- a/Apple-TV/AppleTVAppDelegate.m
+++ b/Apple-TV/AppleTVAppDelegate.m
@@ -48,6 +48,7 @@
                                   kVLCSettingDeinterlace : kVLCSettingDeinterlaceDefaultValue,
                                   kVLCSettingHardwareDecoding : kVLCSettingHardwareDecodingDefault,
                                   kVLCSettingNetworkCaching : kVLCSettingNetworkCachingDefaultValue,
+                                  kVLCSettingEqualizerProfileDisabled : @(YES),
                                   kVLCSettingEqualizerProfile : kVLCSettingEqualizerProfileDefaultValue,
                                   kVLCSettingPlaybackForwardSkipLength : kVLCSettingPlaybackForwardSkipLengthDefaultValue,
                                   kVLCSettingPlaybackBackwardSkipLength : kVLCSettingPlaybackBackwardSkipLengthDefaultValue,

--- a/Apple-TV/VLCTVConstants.h
+++ b/Apple-TV/VLCTVConstants.h
@@ -52,6 +52,7 @@
 #define kVLCSettingContinueAudioInBackgroundKey @"BackgroundAudioPlayback"
 #define kVLCSettingSubtitlesFilePath @"sub-file"
 #define kVLCSettingEqualizerProfile @"EqualizerProfile"
+#define kVLCSettingEqualizerProfileDisabled @"EqualizerDisabled"
 #define kVLCSettingEqualizerProfileDefaultValue @(0)
 #define kVLCSettingPlaybackForwardSkipLength @"playback-forward-skip-length"
 #define kVLCSettingPlaybackForwardSkipLengthDefaultValue @(60)

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -77,6 +77,7 @@
                                   kVLCSettingFTPTextEncoding : kVLCSettingFTPTextEncodingDefaultValue,
                                   kVLCSettingWiFiSharingIPv6 : kVLCSettingWiFiSharingIPv6DefaultValue,
                                   kVLCSettingEqualizerProfile : kVLCSettingEqualizerProfileDefaultValue,
+                                  kVLCSettingEqualizerProfileDisabled : @(YES),
                                   kVLCSettingPlaybackForwardSkipLength : kVLCSettingPlaybackForwardSkipLengthDefaultValue,
                                   kVLCSettingPlaybackBackwardSkipLength : kVLCSettingPlaybackBackwardSkipLengthDefaultValue,
                                   kVLCSettingOpenAppForPlayback : kVLCSettingOpenAppForPlaybackDefaultValue,

--- a/Sources/VLCConstants.h
+++ b/Sources/VLCConstants.h
@@ -61,6 +61,7 @@
 #define kVLCSettingWiFiSharingIPv6 @"wifi-sharing-ipv6"
 #define kVLCSettingWiFiSharingIPv6DefaultValue @(NO)
 #define kVLCSettingEqualizerProfile @"EqualizerProfile"
+#define kVLCSettingEqualizerProfileDisabled @"EqualizerDisabled"
 #define kVLCSettingEqualizerProfileDefaultValue @(0)
 #define kVLCSettingPlaybackForwardSkipLength @"playback-forward-skip-length"
 #define kVLCSettingPlaybackForwardSkipLengthDefaultValue @(60)

--- a/Sources/VLCEqualizerView.m
+++ b/Sources/VLCEqualizerView.m
@@ -328,18 +328,22 @@
 
     NSInteger row = indexPath.row;
 
-    cell.textLabel.text = [[self.delegate equalizerProfiles] objectAtIndex:row];
-    unsigned int profile = (unsigned int)[[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingEqualizerProfile] integerValue];
+    cell.textLabel.text = row == 0 ? NSLocalizedString(@"OFF", nil) : [[self.delegate equalizerProfiles] objectAtIndex:row - 1];
 
-    if (profile == row)
+    unsigned int profile = (unsigned int)[[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingEqualizerProfile] integerValue];
+    BOOL equalizerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:kVLCSettingEqualizerProfileDisabled];
+    if (row == 0 && equalizerDisabled) {
         [cell setShowsCurrentTrack];
+    } else if (!equalizerDisabled && profile + 1 == row) {
+        [cell setShowsCurrentTrack];
+    }
 
     return cell;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return [self.delegate equalizerProfiles].count;
+    return [self.delegate equalizerProfiles].count +1;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -229,10 +229,14 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
         return;
     }
 
-    // Set last selected equalizer profile
-    unsigned int profile = (unsigned int)[[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingEqualizerProfile] integerValue];
-    [_mediaPlayer resetEqualizerFromProfile:profile];
-    [_mediaPlayer setPreAmplification:[_mediaPlayer preAmplification]];
+    // Set last selected equalizer profile if enabled
+    _mediaPlayer.equalizerEnabled = ![[NSUserDefaults standardUserDefaults] boolForKey:kVLCSettingEqualizerProfileDisabled];
+
+    if (_mediaPlayer.equalizerEnabled) {
+        unsigned int profile = (unsigned int)[[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingEqualizerProfile] integerValue];
+        [_mediaPlayer resetEqualizerFromProfile:profile];
+        [_mediaPlayer setPreAmplification:[_mediaPlayer preAmplification]];
+    }
 
     _mediaWasJustStarted = YES;
 
@@ -1063,8 +1067,12 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
 
 - (void)resetEqualizerFromProfile:(unsigned int)profile
 {
-    [[NSUserDefaults standardUserDefaults] setObject:@(profile) forKey:kVLCSettingEqualizerProfile];
-    [_mediaPlayer resetEqualizerFromProfile:profile];
+    _mediaPlayer.equalizerEnabled = profile != 0;
+    [[NSUserDefaults standardUserDefaults] setBool:profile == 0 forKey:kVLCSettingEqualizerProfileDisabled];
+    if (profile != 0) {
+        [[NSUserDefaults standardUserDefaults] setObject:@(profile - 1) forKey:kVLCSettingEqualizerProfile];
+        [_mediaPlayer resetEqualizerFromProfile:profile - 1];
+    }
 }
 
 - (void)setPreAmplification:(CGFloat)preAmplification


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
For now this adds a row with an Off state which, when selected turns off the equalizer, which is also now disabled by default 