### PR TITLE
VLCTabBarCoordinator: Propagate childForStatusBarStyle

### DIFF
--- a/Sources/AppearanceManager.swift
+++ b/Sources/AppearanceManager.swift
@@ -49,4 +49,8 @@ extension UINavigationController {
     override open var preferredStatusBarStyle: UIStatusBarStyle {
         return PresentationTheme.current.colors.statusBarStyle
     }
+
+    override open var childForStatusBarStyle: UIViewController? {
+        return self.topViewController
+    }
 }


### PR DESCRIPTION
In the case of VLCMovieViewController, we need to propagate it in order
to always set the preferred status bar style to .lightContent

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

In the case of VLCMovieViewController, we need to propagate it in order to always set the preferred status bar style to `.lightContent`