### PR TITLE
Playlist: Add reordering

### DIFF
--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -22,6 +22,7 @@ class CollectionModel: MLBaseModel {
         self.mediaCollection = mediaCollection
         files = mediaCollection.files()
         sortModel = mediaCollection.sortModel() ?? SortModel([.default])
+        medialibrary.addObserver(self)
     }
 
     func append(_ item: VLCMLMedia) {
@@ -50,6 +51,16 @@ class CollectionModel: MLBaseModel {
 extension CollectionModel: EditableMLModel {
     func editCellType() -> BaseCollectionViewCell.Type {
         return MediaEditCell.self
+    }
+}
+
+// MARK: - MediaLibraryObserver
+extension CollectionModel: MediaLibraryObserver {
+    func medialibrary(_ medialibrary: MediaLibraryService, didModifyPlaylists playlists: [VLCMLPlaylist]) {
+        if mediaCollection is VLCMLPlaylist {
+            files = mediaCollection.files()
+            updateView?()
+        }
     }
 }
 

--- a/SharedSources/MediaLibraryService.swift
+++ b/SharedSources/MediaLibraryService.swift
@@ -67,6 +67,9 @@ extension NSNotification {
                                      didAddPlaylists playlists: [VLCMLPlaylist])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
+                                     didModifyPlaylists playlists: [VLCMLPlaylist])
+
+    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeletePlaylistsWithIds playlistsIds: [NSNumber])
 }
 
@@ -445,6 +448,12 @@ extension MediaLibraryService {
     func medialibrary(_ medialibrary: VLCMediaLibrary, didAdd playlists: [VLCMLPlaylist]) {
         for observer in observers {
             observer.value.observer?.medialibrary?(self, didAddPlaylists: playlists)
+        }
+    }
+
+    func medialibrary(_ medialibrary: VLCMediaLibrary, didModifyPlaylists playlists: [VLCMLPlaylist]) {
+        for observer in observers {
+            observer.value.observer?.medialibrary?(self, didModifyPlaylists: playlists)
         }
     }
 

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -29,6 +29,7 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
 
     private var editToolbarConstraint: NSLayoutConstraint?
     private var cachedCellSize = CGSize.zero
+    private var longPressGesture: UILongPressGestureRecognizer!
 
 //    @available(iOS 11.0, *)
 //    lazy var dragAndDropManager: VLCDragAndDropManager = { () -> VLCDragAndDropManager<T> in
@@ -331,6 +332,9 @@ private extension VLCMediaCategoryViewController {
         }
         collectionView?.backgroundColor = PresentationTheme.current.colors.background
         collectionView?.alwaysBounceVertical = true
+
+        longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongGesture(gesture:)))
+        collectionView?.addGestureRecognizer(longPressGesture)
         if #available(iOS 11.0, *) {
             collectionView?.contentInsetAdjustmentBehavior = .always
             //            collectionView?.dragDelegate = dragAndDropManager
@@ -349,6 +353,23 @@ private extension VLCMediaCategoryViewController {
                 backgroundview.layer.cornerRadius = 10
                 backgroundview.clipsToBounds = true
             }
+        }
+    }
+
+    @objc func handleLongGesture(gesture: UILongPressGestureRecognizer) {
+
+        switch gesture.state {
+        case .began:
+            guard let selectedIndexPath = collectionView.indexPathForItem(at: gesture.location(in: collectionView)) else {
+                break
+            }
+            collectionView.beginInteractiveMovementForItem(at: selectedIndexPath)
+        case .changed:
+            collectionView.updateInteractiveMovementTargetPosition(gesture.location(in: gesture.view!))
+        case .ended:
+            collectionView.endInteractiveMovement()
+        default:
+            collectionView.cancelInteractiveMovement()
         }
     }
 }

--- a/Sources/VLCEditController.swift
+++ b/Sources/VLCEditController.swift
@@ -207,6 +207,21 @@ extension VLCEditController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
     }
+
+    func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        guard let collectionModel = model as? CollectionModel, let playlist = collectionModel.mediaCollection as? VLCMLPlaylist else {
+            assertionFailure("can Move should've been false")
+            return
+        }
+        playlist.moveMedia(fromPosition: UInt32(sourceIndexPath.row), toDestination: UInt32(destinationIndexPath.row))
+    }
+
+    func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
+        if let collectionModel = model as? CollectionModel, collectionModel.mediaCollection is VLCMLPlaylist {
+            return true
+        }
+        return false
+    }
 }
 
 // MARK: - UICollectionViewDelegate


### PR DESCRIPTION
This adds a longpressgesture recognizer, only for playlists we enable the ability to move cells
we added  the notification for playlists modified and propogate that to the collectionmodel
Since there seems to be a bug in Medialibrary which doesn't seem to return the correct playlist we just update all playlists

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
There are two/three tickets that need to be filed once this is merged.
1. the cell flickers after reordering with the wrong thumbnail but then updates
2. if we reorder a currently playing playlist it will not update the current playlist yet
3. there seems to be an underlying bug in medialibrary for didmodifyPlaylist, it returns 3 playlists even though only one playlist changed, which makes it hard to just reload the playlist which changed, additionally our playlist is not part of that change   