### PR TITLE
delete: Artist, Album and Genre can't be deleted

### DIFF
--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -35,7 +35,7 @@ class AlbumModel: MLBaseModel {
     }
 
     func delete(_ items: [VLCMLObject]) {
-        preconditionFailure("AlbumModel: Cannot delete album")
+        preconditionFailure("AlbumModel: Albums can not be deleted, they disappear when their last title got deleted")
     }
 
     func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -35,7 +35,7 @@ class ArtistModel: MLBaseModel {
     }
 
     func delete(_ items: [VLCMLObject]) {
-        preconditionFailure("ArtistModel: Cannot delete artist")
+        preconditionFailure("ArtistModel: Artists can not be deleted, they disappear when their last title got deleted")
     }
 
     func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {

--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -35,7 +35,7 @@ class GenreModel: MLBaseModel {
     }
 
     func delete(_ items: [VLCMLObject]) {
-        preconditionFailure("GenreModel: Cannot delete genre")
+        preconditionFailure("GenreModel: Genres can not be deleted, they disappear when their last title got deleted")
     }
 
     func createPlaylist(_ name: String, _ fileIndexes: Set<IndexPath>? = nil) {

--- a/Sources/VLCEditToolbar.swift
+++ b/Sources/VLCEditToolbar.swift
@@ -72,8 +72,12 @@ class VLCEditToolbar: UIView {
     }
 
     private func setupStackView() {
-        let stackView = UIStackView(arrangedSubviews: [addToPlaylistButton, deleteButton, shareButton])
+        let stackView = UIStackView(arrangedSubviews: [addToPlaylistButton])
         let file = category.anyfiles.first
+        if !(file is VLCMLArtist) && !(file is VLCMLGenre) && !(file is VLCMLAlbum) {
+            stackView.addArrangedSubview(deleteButton)
+        }
+        stackView.addArrangedSubview(shareButton)
         if !(file is VLCMLAlbum) && !(file is VLCMLArtist) && !(file is VLCMLGenre) {
             stackView.addArrangedSubview(renameButton)
         }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
also remove that option from genre and album to mirror android