### PR TITLE
Add Corespotlight

### DIFF
--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -63,3 +63,94 @@ extension VLCMLMedia {
         return integer == 0
     }
 }
+
+// MARK: - CoreSpotlight
+
+extension VLCMLMedia {
+    func coreSpotlightAttributeSet() -> CSSearchableItemAttributeSet {
+        let attributeSet = CSSearchableItemAttributeSet(itemContentType: "public.audiovisual-content")
+        attributeSet.title = title
+        attributeSet.metadataModificationDate = Date()
+        attributeSet.addedDate = Date()
+        attributeSet.duration = NSNumber(value: duration() / 1000)
+        attributeSet.streamable = 0
+        attributeSet.deliveryType = 0
+        attributeSet.local = 1
+        attributeSet.playCount = NSNumber(value: playCount())
+        if isThumbnailGenerated() {
+            attributeSet.thumbnailData = UIImage(contentsOfFile: thumbnail.path)?.jpegData(compressionQuality: 0.9)
+        }
+        attributeSet.codecs = codecs()
+        attributeSet.languages = languages()
+        if let audioTracks = audioTracks {
+            for track in audioTracks {
+                attributeSet.audioBitRate = NSNumber(value: track.bitrate())
+                attributeSet.audioChannelCount = NSNumber(value: track.nbChannels())
+                attributeSet.audioSampleRate = NSNumber(value: track.sampleRate())
+            }
+        }
+        if let albumTrack = albumTrack {
+            if let genre = albumTrack.genre {
+                attributeSet.genre = genre.name
+            }
+            if let artist = albumTrack.artist {
+                attributeSet.artist = artist.name
+            }
+            attributeSet.audioTrackNumber = NSNumber(value:albumTrack.trackNumber())
+            if let album = albumTrack.album {
+                attributeSet.artist = album.title
+            }
+        }
+
+        return attributeSet
+    }
+
+    func codecs() -> [String] {
+        var codecs = [String]()
+        if let videoTracks = videoTracks {
+            for track in videoTracks {
+                codecs.append(track.codec)
+            }
+        }
+        if let audioTracks = audioTracks {
+            for track in audioTracks {
+                codecs.append(track.codec)
+            }
+        }
+        if let subtitleTracks = subtitleTracks {
+            for track in subtitleTracks {
+                codecs.append(track.codec)
+            }
+        }
+        return codecs
+    }
+
+    func languages() -> [String] {
+        var languages = [String]()
+
+        if let videoTracks = videoTracks {
+            for track in videoTracks where track.language != "" {
+                languages.append(track.language)
+            }
+        }
+        if let audioTracks = audioTracks {
+            for track in audioTracks where track.language != "" {
+                languages.append(track.language)
+            }
+        }
+        if let subtitleTracks = subtitleTracks {
+            for track in subtitleTracks where track.language != "" {
+                languages.append(track.language)
+            }
+        }
+        return languages
+    }
+
+    func updateCoreSpotlightEntry() {
+        if !KeychainCoordinator.passcodeLockEnabled {
+            let groupIdentifier = ProcessInfo.processInfo.environment["GROUP_IDENTIFIER"]
+            let item = CSSearchableItem(uniqueIdentifier: "\(identifier())", domainIdentifier: groupIdentifier, attributeSet: coreSpotlightAttributeSet())
+            CSSearchableIndex.default().indexSearchableItems([item], completionHandler: nil)
+        }
+    }
+}

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -233,10 +233,24 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let media = model.anyfiles[indexPath.row] as? VLCMLMedia {
             play(media: media)
+            createSpotlightItem(media: media)
         } else if let mediaCollection = model.anyfiles[indexPath.row] as? MediaCollectionModel {
             let collectionViewController = VLCCollectionCategoryViewController(services, mediaCollection: mediaCollection)
             navigationController?.pushViewController(collectionViewController, animated: true)
         }
+    }
+
+    func createSpotlightItem(media: VLCMLMedia) {
+        if KeychainCoordinator.passcodeLockEnabled {
+            return
+        }
+        userActivity = NSUserActivity(activityType: kVLCUserActivityPlaying)
+        userActivity?.title = media.title
+        userActivity?.contentAttributeSet = media.coreSpotlightAttributeSet()
+        userActivity?.userInfo = ["playingmedia" : media.identifier()]
+        userActivity?.isEligibleForSearch = true
+        userActivity?.isEligibleForHandoff = true
+        userActivity?.becomeCurrent()
     }
 }
 

--- a/Sources/VLCConstants.h
+++ b/Sources/VLCConstants.h
@@ -97,8 +97,6 @@
 #define kVLCStoreGDriveCredentials @"kVLCStoreGDriveCredentials"
 
 #define kVLCUserActivityPlaying @"org.videolan.vlc-ios.playing"
-#define kVLCUserActivityLibrarySelection @"org.videolan.vlc-ios.libraryselection"
-#define kVLCUserActivityLibraryMode @"org.videolan.vlc-ios.librarymode"
 
 #define kVLCApplicationShortcutLocalVideo @"ApplicationShortcutLocalVideo"
 #define kVLCApplicationShortcutLocalAudio @"ApplicationShortcutLocalAudio"

--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -145,17 +145,6 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
     }
 }
 
-- (void)updateUIAndCoreSpotlightForPasscodeSetting:(BOOL)passcodeOn
-{
-    [self filterCellsWithAnimation:YES];
-
-    [[MLMediaLibrary sharedMediaLibrary] setSpotlightIndexingEnabled:!passcodeOn];
-    if (passcodeOn) {
-        // delete whole index for VLC
-        [[CSSearchableIndex defaultSearchableIndex] deleteAllSearchableItemsWithCompletionHandler:nil];
-    }
-}
-
 - (void)showAbout
 {
     VLCAboutViewController *aboutVC = [[VLCAboutViewController alloc] init];
@@ -191,10 +180,11 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
     NSError *error = nil;
     [VLCKeychainCoordinator setPasscodeWithPasscode:passcode error:&error];
     if (error == nil) {
+        if (passcode != nil) {
+            [[CSSearchableIndex defaultSearchableIndex] deleteAllSearchableItemsWithCompletionHandler:nil];
+        }
         //Set manually the value to enable/disable the UISwitch.
-        BOOL passcodeEnabled = passcode != nil;
-        [[NSUserDefaults standardUserDefaults] setBool:passcodeEnabled forKey:kVLCSettingPasscodeOnKey];
-        [self updateUIAndCoreSpotlightForPasscodeSetting:passcode != nil];
+        [self filterCellsWithAnimation:YES];
     }
     if ([self.navigationController.presentedViewController isKindOfClass:[UINavigationController class]] && [((UINavigationController *)self.navigationController.presentedViewController).viewControllers.firstObject isKindOfClass:[PAPasscodeViewController class]]) {
         [self.navigationController.presentedViewController dismissViewControllerAnimated:YES completion:nil];


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
this adds corespotlight to the app. 
It sets isspotlight enabled on startup 
it updates corespotlight when an item is played. 
it correctly handles a tap on a corespotlight item and starts playback of that item
it also observes the userdefault for passcode and sets is spotlightenabled to false when it is set