### PR TITLE
Add to existing playlists

### DIFF
--- a/Resources/Xib/AddToPlaylist/AddToPlaylistView.xib
+++ b/Resources/Xib/AddToPlaylist/AddToPlaylistView.xib
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddToPlaylistViewController" customModule="VLC" customModuleProvider="target">
+            <connections>
+                <outlet property="newPlaylistButton" destination="A6v-5Z-MTf" id="la1-o2-CNd"/>
+                <outlet property="playlistCollectionView" destination="Ozj-oC-7Dg" id="h4b-YS-wRi"/>
+                <outlet property="view" destination="GSO-Mh-jPo" id="RMB-UZ-7lQ"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" restorationIdentifier="AddToPlaylistView" id="GSO-Mh-jPo" userLabel="AddToPlaylistView">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A6v-5Z-MTf">
+                    <rect key="frame" x="137" y="59" width="140" height="40"/>
+                    <color key="backgroundColor" red="1" green="0.53333333329999999" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="40" id="TSH-AI-tWF"/>
+                        <constraint firstAttribute="width" constant="140" id="yiR-DN-Qy2"/>
+                    </constraints>
+                    <color key="tintColor" red="0.59460381650000005" green="0.83921135540000003" blue="0.31552115819999998" alpha="1" colorSpace="calibratedRGB"/>
+                    <state key="normal" title="New Playlist">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <connections>
+                        <action selector="handleNewPlaylist:" destination="-1" eventType="touchUpInside" id="Yss-xO-E0U"/>
+                    </connections>
+                </button>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Ozj-oC-7Dg">
+                    <rect key="frame" x="0.0" y="114" width="414" height="782"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="o3C-iH-Udd">
+                        <size key="itemSize" width="50" height="50"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="Ozj-oC-7Dg" firstAttribute="top" secondItem="A6v-5Z-MTf" secondAttribute="bottom" constant="15" id="1dq-rp-afA"/>
+                <constraint firstItem="Ozj-oC-7Dg" firstAttribute="leading" secondItem="SK5-46-lSh" secondAttribute="leading" id="23e-in-C0h"/>
+                <constraint firstItem="A6v-5Z-MTf" firstAttribute="centerX" secondItem="SK5-46-lSh" secondAttribute="centerX" id="9K9-Ci-hVU"/>
+                <constraint firstAttribute="bottom" secondItem="Ozj-oC-7Dg" secondAttribute="bottom" id="GPT-DA-XyU"/>
+                <constraint firstItem="Ozj-oC-7Dg" firstAttribute="trailing" secondItem="SK5-46-lSh" secondAttribute="trailing" id="Iyu-57-LOq"/>
+                <constraint firstItem="A6v-5Z-MTf" firstAttribute="top" secondItem="SK5-46-lSh" secondAttribute="top" constant="15" id="uRg-QQ-pRZ"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="SK5-46-lSh"/>
+            <point key="canvasLocation" x="47.826086956521742" y="35.491071428571423"/>
+        </view>
+    </objects>
+</document>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -323,7 +323,7 @@
 "ADD_TO_PLAYLIST" = "Add to Playlist";
 
 "PLAYLIST_PLACEHOLDER" = "Playlist title";
-"PLAYLIST_DESCRIPTION" = "Choose a title for your new Playlist";
+"PLAYLIST_DESCRIPTION" = "Choose a title for your new playlist";
 
 "RENAME_PLACEHOLDER" = "New title";
 "ERROR_RENAME_FAILED" = "Renaming failed";

--- a/Sources/AddToPlaylistViewController.swift
+++ b/Sources/AddToPlaylistViewController.swift
@@ -1,0 +1,200 @@
+/*****************************************************************************
+ * AddToPlaylistViewController.swift
+ *
+ * Copyright © 2019 VLC authors and VideoLAN
+ *
+ * Authors: Soomin Lee <bubu@mikan.io>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
+
+import Foundation
+
+protocol AddToPlaylistViewControllerDelegate: class {
+    func addToPlaylistViewController(_ addToPlaylistViewController: AddToPlaylistViewController,
+                                     didSelectPlaylist playlist: VLCMLPlaylist)
+    func addToPlaylistViewController(_ addToPlaylistViewController: AddToPlaylistViewController,
+                                     newPlaylistWithName name: String)
+}
+
+class AddToPlaylistViewController: UIViewController {
+    @IBOutlet private weak var newPlaylistButton: UIButton!
+    @IBOutlet private weak var playlistCollectionView: UICollectionView!
+
+    private let cellHeight: CGFloat = 56
+    private let sidePadding: CGFloat = 8
+
+    var playlists: [VLCMLPlaylist]
+
+    private lazy var collectionViewLayout: UICollectionViewFlowLayout = {
+        let collectionViewLayout = UICollectionViewFlowLayout()
+        collectionViewLayout.minimumLineSpacing = 1
+        collectionViewLayout.minimumInteritemSpacing = 0
+        return collectionViewLayout
+    }()
+
+    weak var delegate: AddToPlaylistViewControllerDelegate?
+
+    init(playlists: [VLCMLPlaylist]) {
+        self.playlists = playlists
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if #available(iOS 11.0, *) {
+            navigationController?.navigationBar.prefersLargeTitles = false
+        }
+        navigationController?.navigationBar.isTranslucent = false
+        playlistCollectionView.reloadData()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        initViews()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .VLCThemeDidChangeNotification,
+                                               object: nil)
+        title = NSLocalizedString("ADD_TO_PLAYLIST", comment: "")
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return PresentationTheme.current.colors.statusBarStyle
+    }
+
+    @objc private func themeDidChange() {
+        view.backgroundColor = PresentationTheme.current.colors.background
+        playlistCollectionView.backgroundColor = PresentationTheme.current.colors.background
+        setNeedsStatusBarAppearanceUpdate()
+    }
+
+    @objc private func dismissView() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    @IBAction private func handleNewPlaylist(_ sender: UIButton) {
+        let alertController = UIAlertController(title: NSLocalizedString("PLAYLISTS", comment: ""),
+                                                message: NSLocalizedString("PLAYLIST_DESCRIPTION", comment: ""),
+                                                preferredStyle: .alert)
+
+        alertController.addTextField(configurationHandler: {
+            textField in
+            textField.placeholder = NSLocalizedString("PLAYLIST_PLACEHOLDER", comment: "")
+        })
+
+        let cancelButton = UIAlertAction(title: NSLocalizedString("BUTTON_CANCEL", comment: ""),
+                                         style: .default)
+
+        let confirmAction = UIAlertAction(title: NSLocalizedString("BUTTON_DONE", comment: ""),
+                                          style: .default) {
+            [weak alertController] _ in
+            guard let alertController = alertController,
+                let textField = alertController.textFields?.first else { return }
+
+            guard let text = textField.text, text != "" else {
+                DispatchQueue.main.async {
+                    VLCAlertViewController.alertViewManager(title: NSLocalizedString("ERROR_EMPTY_NAME",
+                                                                                     comment: ""),
+                                                            viewController: self)
+                }
+                return
+            }
+            self.delegate?.addToPlaylistViewController(self, newPlaylistWithName: text)
+        }
+        alertController.addAction(cancelButton)
+        alertController.addAction(confirmAction)
+        present(alertController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Private initializers
+
+private extension AddToPlaylistViewController {
+    private func initViews() {
+        Bundle.main.loadNibNamed("AddToPlaylistView", owner: self, options: nil)
+        view.backgroundColor = PresentationTheme.current.colors.background
+        setupNavigationBar()
+        setupNewPlaylistButton()
+        setupPlaylistCollectionView()
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("BUTTON_CANCEL",
+                                                                                    comment: ""),
+                                                           style: .done,
+                                                           target: self,
+                                                           action: #selector(dismissView))
+    }
+
+    private func setupNewPlaylistButton() {
+        newPlaylistButton.layer.masksToBounds = true
+        newPlaylistButton.layer.cornerRadius = 10
+        newPlaylistButton.backgroundColor = PresentationTheme.current.colors.orangeUI
+    }
+
+    private func setupPlaylistCollectionView() {
+        let cellNib = UINib(nibName: MediaCollectionViewCell.nibName, bundle: nil)
+        playlistCollectionView.register(cellNib,
+                                        forCellWithReuseIdentifier: MediaCollectionViewCell.defaultReuseIdentifier)
+        playlistCollectionView.delegate = self
+        playlistCollectionView.dataSource = self
+        playlistCollectionView.collectionViewLayout = collectionViewLayout
+        playlistCollectionView.backgroundColor = PresentationTheme.current.colors.background
+    }
+}
+
+// MARK: - UICollectionViewFlowLayout
+
+extension AddToPlaylistViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width - (sidePadding * 2), height: cellHeight)
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: sidePadding, bottom: 0, right: sidePadding)
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension AddToPlaylistViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard indexPath.row <= playlists.count else {
+            assertionFailure("AddToPlaylistViewController: didSelectItemAt: IndexPath out of range.")
+            return
+        }
+        delegate?.addToPlaylistViewController(self, didSelectPlaylist: playlists[indexPath.row])
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension AddToPlaylistViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView,
+                        numberOfItemsInSection section: Int) -> Int {
+        return playlists.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MediaCollectionViewCell.defaultReuseIdentifier,
+                                                            for: indexPath) as? MediaCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        guard indexPath.row <= playlists.count else {
+            assertionFailure("AddToPlaylistViewController: cellForItemAt: IndexPath out of range.")
+            return UICollectionViewCell()
+        }
+        cell.media = playlists[indexPath.row]
+        return cell
+    }
+}

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -319,6 +319,12 @@ extension VLCMediaCategoryViewController: VLCEditControllerDelegate {
     func editController(editController: VLCEditController, cellforItemAt indexPath: IndexPath) -> MediaEditCell? {
         return collectionView.cellForItem(at: indexPath) as? MediaEditCell
     }
+
+    func editController(editController: VLCEditController,
+                        present viewController: UIViewController) {
+        let newNavigationController = UINavigationController(rootViewController: viewController)
+        navigationController?.present(newNavigationController, animated: true, completion: nil)
+    }
 }
 
 private extension VLCMediaCategoryViewController {

--- a/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
@@ -29,6 +29,8 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
                 update(artist:artist)
             } else if let movie = media as? VLCMLMedia, movie.subtype() == .unknown {
                 update(movie:movie)
+            } else if let playlist = media as? VLCMLPlaylist {
+                update(playlist: playlist)
             } else {
                 fatalError("needs to be of Type VLCMLMedia or VLCMLAlbum")
             }
@@ -77,6 +79,13 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
             thumbnailView.image = UIImage(contentsOfFile: movie.thumbnail.absoluteString)
         }
         newLabel.isHidden = !movie.isNew()
+    }
+
+    func update(playlist: VLCMLPlaylist) {
+        newLabel.isHidden = true
+        titleLabel.text = playlist.name
+        descriptionLabel.text = playlist.numberOfTracksString()
+        thumbnailView.image = UIImage(contentsOfFile: playlist.artworkMrl())
     }
 
     override class func cellSizeForWidth(_ width: CGFloat) -> CGSize {

--- a/Sources/VLCEditController.swift
+++ b/Sources/VLCEditController.swift
@@ -102,7 +102,8 @@ private extension VLCEditController {
 extension VLCEditController: VLCEditToolbarDelegate {
     func addToNewPlaylist() {
         let alertInfo = TextFieldAlertInfo(alertTitle: NSLocalizedString("PLAYLISTS", comment: ""),
-                                           placeHolder: "NEW_PLAYLIST")
+                                           placeHolder: NSLocalizedString("PLAYLIST_PLACEHOLDER",
+                                                                          comment: ""))
         presentTextFieldAlert(with: alertInfo,
                               completionHandler: {
             [unowned self] text -> Void in

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -250,6 +250,8 @@
 		81334053F6D89AB90E14A1C3 /* libPods-VLC-iOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 91CCB170FBC97B6B93B99E0A /* libPods-VLC-iOSTests.a */; };
 		8D144D6322298E8E00984C46 /* AudioMiniPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D144D6222298E8E00984C46 /* AudioMiniPlayer.swift */; };
 		8D222DC220F779F1009C0D34 /* MediaEditCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D222DC120F779F1009C0D34 /* MediaEditCell.swift */; };
+		8D2AD4D822786F4000393833 /* AddToPlaylistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2AD4D722786F4000393833 /* AddToPlaylistViewController.swift */; };
+		8D2AD4DA227AEE8E00393833 /* AddToPlaylistView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D2AD4D9227AEE8E00393833 /* AddToPlaylistView.xib */; };
 		8D3B4C0E2226E49A00B9F652 /* AudioMiniPlayer.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D3B4C0D2226E49A00B9F652 /* AudioMiniPlayer.xib */; };
 		8D43712D2056AF1600F36458 /* VLCRendererDiscovererManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D43712C2056AF1600F36458 /* VLCRendererDiscovererManager.swift */; };
 		8D437154205808FF00F36458 /* VLCActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D437153205808FF00F36458 /* VLCActionSheet.swift */; };
@@ -822,6 +824,8 @@
 		7FC9CCF39DD8843873A42D34 /* Pods-VLC-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VLC-iOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-VLC-iOSTests/Pods-VLC-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		8D144D6222298E8E00984C46 /* AudioMiniPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMiniPlayer.swift; sourceTree = "<group>"; };
 		8D222DC120F779F1009C0D34 /* MediaEditCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MediaEditCell.swift; path = Sources/MediaEditCell.swift; sourceTree = "<group>"; };
+		8D2AD4D722786F4000393833 /* AddToPlaylistViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddToPlaylistViewController.swift; path = Sources/AddToPlaylistViewController.swift; sourceTree = "<group>"; };
+		8D2AD4D9227AEE8E00393833 /* AddToPlaylistView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddToPlaylistView.xib; sourceTree = "<group>"; };
 		8D3B4C0D2226E49A00B9F652 /* AudioMiniPlayer.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AudioMiniPlayer.xib; sourceTree = "<group>"; };
 		8D43712C2056AF1600F36458 /* VLCRendererDiscovererManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VLCRendererDiscovererManager.swift; path = Sources/VLCRendererDiscovererManager.swift; sourceTree = "<group>"; };
 		8D437153205808FF00F36458 /* VLCActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCActionSheet.swift; sourceTree = "<group>"; };
@@ -1294,6 +1298,7 @@
 				8DF9669C2113317100D0FCD6 /* VLCEditToolbar.swift */,
 				8DF966B021188BDB00D0FCD6 /* VLCEditController.swift */,
 				41B4DA3D21400E8E000BA27D /* MediaEditCell.xib */,
+				8D2AD4D722786F4000393833 /* AddToPlaylistViewController.swift */,
 			);
 			name = "UI Elements";
 			sourceTree = "<group>";
@@ -1596,6 +1601,7 @@
 				7DBBF191183AB4300009A339 /* VLCMovieViewController.xib */,
 				418108792142894A0046A931 /* PlayingExternallyView.xib */,
 				414327A621B6E66E00B061F6 /* PlaybackSpeedView.xib */,
+				8D2AD4D6227869AF00393833 /* AddToPlaylist */,
 			);
 			name = XIBs;
 			sourceTree = "<group>";
@@ -1880,6 +1886,15 @@
 			);
 			name = MiniPlayer;
 			path = Sources/MiniPlayer;
+			sourceTree = "<group>";
+		};
+		8D2AD4D6227869AF00393833 /* AddToPlaylist */ = {
+			isa = PBXGroup;
+			children = (
+				8D2AD4D9227AEE8E00393833 /* AddToPlaylistView.xib */,
+			);
+			name = AddToPlaylist;
+			path = Resources/Xib/AddToPlaylist;
 			sourceTree = "<group>";
 		};
 		8D3B4C0C2226E47900B9F652 /* MiniPlayer */ = {
@@ -2554,6 +2569,7 @@
 				7D63C19518774E0100BD5256 /* VLCFirstStepsThirdPageViewController~ipad.xib in Resources */,
 				7D9870651A3E03D5009CF27D /* papasscode_background@2x.png in Resources */,
 				7D5B26641D6350BF00FE7B4D /* gradient-cell.png in Resources */,
+				8D2AD4DA227AEE8E00393833 /* AddToPlaylistView.xib in Resources */,
 				7D63C19718774F1000BD5256 /* VLCFirstStepsFourthPageViewController~ipad.xib in Resources */,
 				26F1BFD01A770408001DF30C /* libMediaVLC.xml in Resources */,
 				7DBBF1A6183AB4300009A339 /* VLCMovieViewController.xib in Resources */,
@@ -2934,6 +2950,7 @@
 				417CDA231A48D1F300D9ACE7 /* VLCCloudServicesTableViewController.m in Sources */,
 				418B145920179E50000447AA /* VLCDragAndDropManager.swift in Sources */,
 				7D168F7418D4A33F003FAF59 /* UIImage+Blur.m in Sources */,
+				8D2AD4D822786F4000393833 /* AddToPlaylistViewController.swift in Sources */,
 				7DC19ADF1868C7BB00810BF7 /* VLCFirstStepsViewController.m in Sources */,
 				DD3EFF331BDEBCE500B68579 /* VLCLocalNetworkServiceBrowserMediaDiscoverer.m in Sources */,
 				7DE56C1A1AD93F9100E8CA00 /* VLCPlaybackController.m in Sources */,


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This adds the possibility to add any model to an existing playlist.
For now I went for a basic design, it should later be changed with Louis's input.
Additionnaly, the addition of the playlist from collections(genre, artist) will be done in a separate PR.

![view](https://i.gyazo.com/0524dc4a57351f915ab9bb43dde0a462.png)