### PR TITLE
Skip movieDBSessionManager init when no API key is set

### DIFF
--- a/Apple-TV/VLCCloudServicesTVViewController.m
+++ b/Apple-TV/VLCCloudServicesTVViewController.m
@@ -38,9 +38,11 @@
 //    [center addObserver:self selector:@selector(oneDriveSessionUpdated:) name:VLCOneDriveControllerSessionUpdated object:nil];
     [center addObserver:self selector:@selector(boxSessionUpdated:) name:VLCBoxControllerSessionUpdated object:nil];
 
-    MDFMovieDBSessionManager *movieDBSessionManager = [MDFMovieDBSessionManager sharedInstance];
-    movieDBSessionManager.apiKey = kVLCfortvOSMovieDBKey;
-    [movieDBSessionManager fetchProperties];
+    if (![kVLCfortvOSMovieDBKey isEqualToString:@""]) {
+        MDFMovieDBSessionManager *movieDBSessionManager = [MDFMovieDBSessionManager sharedInstance];
+        movieDBSessionManager.apiKey = kVLCfortvOSMovieDBKey;
+        [movieDBSessionManager fetchProperties];
+    }
 
 //    _oneDriveController = [VLCOneDriveController sharedInstance];
     _boxController = [VLCBoxController sharedInstance];

--- a/SharedSources/ServerBrowsing/VLCServerBrowsingController.m
+++ b/SharedSources/ServerBrowsing/VLCServerBrowsingController.m
@@ -35,9 +35,11 @@
         _viewController = viewController;
         _serverBrowser = browser;
 #if TARGET_OS_TV
-        MDFMovieDBSessionManager *movieDBSessionManager = [MDFMovieDBSessionManager sharedInstance];
-        movieDBSessionManager.apiKey = kVLCfortvOSMovieDBKey;
-        [movieDBSessionManager fetchProperties];
+        if (![kVLCfortvOSMovieDBKey isEqualToString:@""]) {
+            MDFMovieDBSessionManager *movieDBSessionManager = [MDFMovieDBSessionManager sharedInstance];
+            movieDBSessionManager.apiKey = kVLCfortvOSMovieDBKey;
+            [movieDBSessionManager fetchProperties];
+        }
 #endif
     }
     return self;


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [ ] I've updated the documentation if necessary.

### Description
I noticed while building VLC over the past few months that browsing a network share causes a lot of Xcode console spam and 401 Unauthorized responses from themoviedb.org. I eventually tracked this down to two instances of movieDBSessionManager being configured when the API key is `""`, which results in 100% bad queries to the remote website. This commit only sets up movieDBSessionManager when the API key is not `""` so that folks who are building and running VLC without one stop generating `GET configuration?apikey=` network requests to themoviedb's site.

I don't have a valid API key, so I can't easily test this, but at the very least my local build continues to work correctly in the network file browser without generating either the 401 Unauth http request or any other new warnings/errors on the console.