### PR TITLE
AudioMiniPlayer: Reduce infoStackView height to align with artwork

### DIFF
--- a/Resources/Xib/MiniPlayer/AudioMiniPlayer.xib
+++ b/Resources/Xib/MiniPlayer/AudioMiniPlayer.xib
@@ -46,17 +46,17 @@
                                     <rect key="frame" x="52" y="0.0" width="157" height="40"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rRG-rj-ixk">
-                                            <rect key="frame" x="0.0" y="0.0" width="157" height="34.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="157" height="33.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aAs-Lc-dt8" userLabel="Title">
-                                                    <rect key="frame" x="0.0" y="0.0" width="157" height="20"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="157" height="19"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cVn-oI-gin" userLabel="Artist">
-                                                    <rect key="frame" x="0.0" y="20" width="157" height="14.5"/>
+                                                    <rect key="frame" x="0.0" y="19" width="157" height="14.5"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
@@ -65,11 +65,12 @@
                                             </subviews>
                                         </stackView>
                                         <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" translatesAutoresizingMaskIntoConstraints="NO" id="IcU-Lc-kf0">
-                                            <rect key="frame" x="0.0" y="38.5" width="157" height="2.5"/>
+                                            <rect key="frame" x="0.0" y="37.5" width="157" height="2.5"/>
                                             <color key="backgroundColor" red="0.1461089551448822" green="0.16114577651023865" blue="0.17342603206634521" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="progressTintColor" red="1" green="0.53333333329999999" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         </progressView>
                                     </subviews>
+                                    <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="1" right="0.0"/>
                                     <viewLayoutGuide key="safeArea" id="qEk-QE-Gm4"/>
                                 </stackView>
                             </subviews>


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

There was an extra pixel with the progressView since UIKit doesn't seem to handle it well.

before:

![image](https://i.gyazo.com/1c1b972e4259101fbf3d4e5e16e8bd87.png)

after: 

![image](https://i.gyazo.com/14e6494b6cd241dd31ac01317566a257.png)
