### PR TITLE
VLCPlayerDisplayController: Fix rotation resizing

### DIFF
--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -49,8 +49,7 @@ class Services: NSObject {
     }
 
     @objc func start() {
-        let tabbarCoordinator = VLCTabBarCoordinator(tabBarController: tabBarController, services: services)
-        childCoordinators.append(tabbarCoordinator)
+        childCoordinators.append(VLCTabBarCoordinator(tabBarController: tabBarController, services: services))
     }
 }
 

--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -38,14 +38,14 @@ class Services: NSObject {
     }
 
     private func setupChildViewControllers() {
-        self.tabBarController.addChild(playerController)
-        self.tabBarController.view.addSubview(playerController.view)
+        tabBarController.addChild(playerController)
+        tabBarController.view.addSubview(playerController.view)
         playerController.view.layoutMargins = UIEdgeInsets(top: 0,
                                                            left: 0,
                                                            bottom: tabBarController.tabBar.frame.size.height,
                                                            right: 0)
         playerController.realBottomAnchor = tabBarController.tabBar.topAnchor
-        playerController.didMove(toParent: self.tabBarController)
+        playerController.didMove(toParent: tabBarController)
     }
 
     @objc func start() {

--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -49,7 +49,6 @@ class Services: NSObject {
     }
 
     @objc func start() {
-
         let tabbarCoordinator = VLCTabBarCoordinator(tabBarController: tabBarController, services: services)
         childCoordinators.append(tabbarCoordinator)
     }

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -66,14 +66,7 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
 - (void)viewDidLoad
 {
     self.view = [[VLCUntouchableView alloc] initWithFrame:self.view.frame];
-}
-
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
-{
-    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        self.view.frame = CGRectMake(0, 0, size.width, size.height);
-    } completion:nil];
+    self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 }
 
 #pragma mark - properties


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
With the hierarchy changes from `4f4e0033`, the view on the controller stopped receiving callbacks for rotation(transitions). This led to the miniplayer being broken on rotation.

Additionally, minor cosmetic and syntax commits.