### PR TITLE
Thumbnail path fix

### DIFF
--- a/Sources/MediaCategoryCells/GenreCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/GenreCollectionViewCell.swift
@@ -31,6 +31,7 @@ class GenreCollectionViewCell: BaseCollectionViewCell {
         super.awakeFromNib()
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: .VLCThemeDidChangeNotification, object: nil)
         themeDidChange()
+        thumbnailView.layer.masksToBounds = true
         thumbnailView.layer.cornerRadius = thumbnailView.frame.size.width / 2.0
     }
 

--- a/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
@@ -52,6 +52,7 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
     }
 
     func update(audiotrack: VLCMLMedia) {
+        thumbnailView.layer.masksToBounds = true
         thumbnailView.layer.cornerRadius = thumbnailView.frame.size.width / 2.0
         titleLabel.text = audiotrack.title
         descriptionLabel.text = audiotrack.albumTrack.artist.name
@@ -67,6 +68,7 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
     }
 
     func update(artist: VLCMLArtist) {
+        thumbnailView.layer.masksToBounds = true
         thumbnailView.layer.cornerRadius = thumbnailView.frame.size.width / 2.0
         titleLabel.text = artist.name
         descriptionLabel.text = artist.numberOfTracksString()

--- a/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
@@ -56,7 +56,7 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
         titleLabel.text = audiotrack.title
         descriptionLabel.text = audiotrack.albumTrack.artist.name
         if audiotrack.isThumbnailGenerated() {
-            thumbnailView.image = UIImage(contentsOfFile: audiotrack.thumbnail.absoluteString)
+            thumbnailView.image = UIImage(contentsOfFile: audiotrack.thumbnail.path)
         }
         newLabel.isHidden = !audiotrack.isNew()
     }
@@ -76,7 +76,7 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
         titleLabel.text = movie.title
         descriptionLabel.text = movie.mediaDuration()
         if movie.isThumbnailGenerated() {
-            thumbnailView.image = UIImage(contentsOfFile: movie.thumbnail.absoluteString)
+            thumbnailView.image = UIImage(contentsOfFile: movie.thumbnail.path)
         }
         newLabel.isHidden = !movie.isNew()
     }

--- a/Sources/MediaCategoryCells/MovieCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MovieCollectionViewCell.swift
@@ -58,7 +58,7 @@ class MovieCollectionViewCell: BaseCollectionViewCell {
         titleLabel.text = movie.title
         descriptionLabel.text = movie.mediaDuration()
         if movie.isThumbnailGenerated() {
-            thumbnailView.image = UIImage(contentsOfFile: movie.thumbnail.absoluteString)
+            thumbnailView.image = UIImage(contentsOfFile: movie.thumbnail.path)
         }
         let progress = movie.mediaProgress()
         progressView.isHidden = progress == 0

--- a/Sources/MediaEditCell.swift
+++ b/Sources/MediaEditCell.swift
@@ -64,7 +64,7 @@ class MediaEditCell: BaseCollectionViewCell {
         timeLabel.text = movie.mediaDuration()
         sizeLabel.text = movie.formatSize()
         if movie.isThumbnailGenerated() {
-            thumbnailImageView.image = UIImage(contentsOfFile: movie.thumbnail.absoluteString)
+            thumbnailImageView.image = UIImage(contentsOfFile: movie.thumbnail.path)
         }
     }
 
@@ -73,7 +73,7 @@ class MediaEditCell: BaseCollectionViewCell {
         timeLabel.text = audio.mediaDuration()
         sizeLabel.text = audio.formatSize()
         if audio.isThumbnailGenerated() {
-            thumbnailImageView.image = UIImage(contentsOfFile: audio.thumbnail.absoluteString)
+            thumbnailImageView.image = UIImage(contentsOfFile: audio.thumbnail.path)
         }
         thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.size.height / 2
     }

--- a/Sources/MediaEditCell.swift
+++ b/Sources/MediaEditCell.swift
@@ -75,12 +75,14 @@ class MediaEditCell: BaseCollectionViewCell {
         if audio.isThumbnailGenerated() {
             thumbnailImageView.image = UIImage(contentsOfFile: audio.thumbnail.path)
         }
+        thumbnailImageView.layer.masksToBounds = true
         thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.size.height / 2
     }
 
     func updateForArtist(artist: VLCMLArtist) {
         //TODO: add size, number of tracks, thumbnail
         titleLabel.text = artist.name
+        thumbnailImageView.layer.masksToBounds = true
         thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.size.height / 2
     }
 
@@ -93,6 +95,7 @@ class MediaEditCell: BaseCollectionViewCell {
     func updateForGenre(genre: VLCMLGenre) {
         titleLabel.text = genre.name
         timeLabel.text = genre.numberOfTracksString()
+        thumbnailImageView.layer.masksToBounds = true
         thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.size.height / 2
         //TODO: add thumbnail
     }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This fixes the current thumbnailing which didn't work all the time because of the wrong path.
