### PR TITLE
Fix sort actionsheet

### DIFF
--- a/Sources/ActionSheet/ActionSheet.swift
+++ b/Sources/ActionSheet/ActionSheet.swift
@@ -285,13 +285,10 @@ extension ActionSheet {
                         mainStackView.frame.origin.y += mainStackView.frame.size.height
                         backgroundView.alpha = 0
             }, completion: {
-                [presentingViewController] finished in
-                presentingViewController?.dismiss(animated: false,
-                                                  completion: {
-                                                    [unowned self] in
-                                                    // When everything is complete, reset the frame for the re-use
-                                                    self.mainStackView.frame = realMainStackView
-                })
+                [unowned self, presentingViewController] finished in
+                // When everything is complete, reset the frame for the re-use
+                self.mainStackView.frame = realMainStackView
+                presentingViewController?.dismiss(animated: false, completion: nil)
         })
     }
 }

--- a/Sources/ActionSheet/ActionSheet.swift
+++ b/Sources/ActionSheet/ActionSheet.swift
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * VLCActionSheet.swift
+ * ActionSheet.swift
  *
  * Copyright © 2018 VLC authors and VideoLAN
  * Copyright © 2018 Videolabs
@@ -12,27 +12,30 @@
 import Foundation
 import UIKit
 
-@objc protocol VLCActionSheetDataSource {
+@objc(VLCActionSheetDataSource)
+protocol ActionSheetDataSource {
     @objc func numberOfRows() -> Int
     @objc func actionSheet(collectionView: UICollectionView,
                            cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
 }
 
-@objc protocol VLCActionSheetDelegate {
+@objc(VLCActionSheetDelegate)
+protocol ActionSheetDelegate {
     @objc optional func headerViewTitle() -> String?
     @objc func itemAtIndexPath(_ indexPath: IndexPath) -> Any?
     @objc optional func actionSheet(collectionView: UICollectionView,
                                     didSelectItem item: Any, At indexPath: IndexPath)
 }
 
-// MARK: VLCActionSheet
+// MARK: ActionSheet
 
-class VLCActionSheet: UIViewController {
+@objc(VLCActionSheet)
+class ActionSheet: UIViewController {
 
     private let cellHeight: CGFloat = 50
 
-    @objc weak var dataSource: VLCActionSheetDataSource?
-    @objc weak var delegate: VLCActionSheetDelegate?
+    @objc weak var dataSource: ActionSheetDataSource?
+    @objc weak var delegate: ActionSheetDelegate?
 
     var action: ((_ item: Any) -> Void)?
 
@@ -61,14 +64,14 @@ class VLCActionSheet: UIViewController {
         collectionView.backgroundColor = PresentationTheme.current.colors.background
         collectionView.alwaysBounceVertical = true
         collectionView.showsVerticalScrollIndicator = false
-        collectionView.register(VLCActionSheetCell.self,
-                                forCellWithReuseIdentifier: VLCActionSheetCell.identifier)
+        collectionView.register(ActionSheetCell.self,
+                                forCellWithReuseIdentifier: ActionSheetCell.identifier)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
 
-    lazy var headerView: VLCActionSheetSectionHeader = {
-        let headerView = VLCActionSheetSectionHeader()
+    lazy var headerView: ActionSheetSectionHeader = {
+        let headerView = ActionSheetSectionHeader()
         headerView.title.text = delegate?.headerViewTitle?() ?? "Default header title"
         headerView.title.textColor = PresentationTheme.current.colors.cellTextColor
         headerView.backgroundColor = PresentationTheme.current.colors.background
@@ -204,7 +207,7 @@ class VLCActionSheet: UIViewController {
         headerView.title.textColor = PresentationTheme.current.colors.cellTextColor
         bottomBackgroundView.backgroundColor = PresentationTheme.current.colors.background
         for cell in collectionView.visibleCells {
-            if let cell = cell as? VLCActionSheetCell {
+            if let cell = cell as? ActionSheetCell {
                 cell.backgroundColor = PresentationTheme.current.colors.background
                 cell.name.textColor = PresentationTheme.current.colors.cellTextColor
             }
@@ -215,7 +218,7 @@ class VLCActionSheet: UIViewController {
 
 // MARK: Private setup methods
 
-private extension VLCActionSheet {
+private extension ActionSheet {
     private func setuplHeaderViewConstraints() {
         NSLayoutConstraint.activate([
             headerView.heightAnchor.constraint(equalToConstant: cellHeight),
@@ -251,7 +254,7 @@ private extension VLCActionSheet {
 
 // MARK: Helpers
 
-private extension VLCActionSheet {
+private extension ActionSheet {
     private func setHeaderRoundedCorners() {
         let roundedCornerPath = UIBezierPath(roundedRect: headerView.bounds,
                                              byRoundingCorners: [.topLeft, .topRight],
@@ -264,7 +267,7 @@ private extension VLCActionSheet {
 
 // MARK: Actions
 
-extension VLCActionSheet {
+extension ActionSheet {
     @objc func setAction(closure action: @escaping (_ item: Any) -> Void) {
         self.action = action
     }
@@ -295,7 +298,7 @@ extension VLCActionSheet {
 
 // MARK: UICollectionViewDelegateFlowLayout
 
-extension VLCActionSheet: UICollectionViewDelegateFlowLayout {
+extension ActionSheet: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -305,7 +308,7 @@ extension VLCActionSheet: UICollectionViewDelegateFlowLayout {
 
 // MARK: UICollectionViewDelegate
 
-extension VLCActionSheet: UICollectionViewDelegate {
+extension ActionSheet: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView,
                         didSelectItemAt indexPath: IndexPath) {
         if let delegate = delegate, let item = delegate.itemAtIndexPath(indexPath) {
@@ -318,7 +321,7 @@ extension VLCActionSheet: UICollectionViewDelegate {
 
 // MARK: UICollectionViewDataSource
 
-extension VLCActionSheet: UICollectionViewDataSource {
+extension ActionSheet: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView,
                         numberOfItemsInSection section: Int) -> Int {
         if let dataSource = dataSource {

--- a/Sources/ActionSheet/ActionSheetCell.swift
+++ b/Sources/ActionSheet/ActionSheetCell.swift
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * VLCActionSheetCell.swift
+ * ActionSheetCell.swift
  *
  * Copyright © 2018 VLC authors and VideoLAN
  * Copyright © 2018 Videolabs
@@ -9,7 +9,7 @@
  * Refer to the COPYING file of the official project for license.
  *****************************************************************************/
 
-class VLCActionSheetCell: UICollectionViewCell {
+class ActionSheetCell: UICollectionViewCell {
 
     @objc static var identifier: String {
         return String(describing: self)

--- a/Sources/ActionSheet/ActionSheetSectionHeader.swift
+++ b/Sources/ActionSheet/ActionSheetSectionHeader.swift
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * VLCActionSheetSectionHeader.swift
+ * ActionSheetSectionHeader.swift
  *
  * Copyright © 2018 VLC authors and VideoLAN
  * Copyright © 2018 Videolabs
@@ -9,7 +9,7 @@
  * Refer to the COPYING file of the official project for license.
  *****************************************************************************/
 
-class VLCActionSheetSectionHeader: UIView {
+class ActionSheetSectionHeader: UIView {
 
     static let identifier = "VLCActionSheetSectionHeader"
 

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -36,8 +36,8 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
 //        VLCDragAndDropManager<T>(subcategory: VLCMediaSubcategories<>)
 //    }()
 
-    @objc private lazy var sortActionSheet: VLCActionSheet = {
-        let actionSheet = VLCActionSheet()
+    @objc private lazy var sortActionSheet: ActionSheet = {
+        let actionSheet = ActionSheet()
         actionSheet.delegate = self
         actionSheet.dataSource = self
         actionSheet.modalPresentationStyle = .custom
@@ -273,7 +273,7 @@ extension VLCMediaCategoryViewController {
 
 // MARK: VLCActionSheetDelegate
 
-extension VLCMediaCategoryViewController: VLCActionSheetDelegate {
+extension VLCMediaCategoryViewController: ActionSheetDelegate {
     func headerViewTitle() -> String? {
         return NSLocalizedString("HEADER_TITLE_SORT", comment: "")
     }
@@ -292,14 +292,14 @@ extension VLCMediaCategoryViewController: VLCActionSheetDelegate {
 
 // MARK: VLCActionSheetDataSource
 
-extension VLCMediaCategoryViewController: VLCActionSheetDataSource {
+extension VLCMediaCategoryViewController: ActionSheetDataSource {
     func numberOfRows() -> Int {
         return model.sortModel.sortingCriteria.count
     }
 
     func actionSheet(collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: VLCActionSheetCell.identifier, for: indexPath) as? VLCActionSheetCell else {
+            withReuseIdentifier: ActionSheetCell.identifier, for: indexPath) as? ActionSheetCell else {
                 assertionFailure("VLCMediaCategoryViewController: VLCActionSheetDataSource: Unable to dequeue reusable cell")
                 return UICollectionViewCell()
         }

--- a/Sources/VLCActionSheet/VLCActionSheet.swift
+++ b/Sources/VLCActionSheet/VLCActionSheet.swift
@@ -14,13 +14,15 @@ import UIKit
 
 @objc protocol VLCActionSheetDataSource {
     @objc func numberOfRows() -> Int
-    @objc func actionSheet(collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
+    @objc func actionSheet(collectionView: UICollectionView,
+                           cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
 }
 
 @objc protocol VLCActionSheetDelegate {
     @objc optional func headerViewTitle() -> String?
     @objc func itemAtIndexPath(_ indexPath: IndexPath) -> Any?
-    @objc optional func actionSheet(collectionView: UICollectionView, didSelectItem item: Any, At indexPath: IndexPath)
+    @objc optional func actionSheet(collectionView: UICollectionView,
+                                    didSelectItem item: Any, At indexPath: IndexPath)
 }
 
 // MARK: VLCActionSheet
@@ -39,7 +41,8 @@ class VLCActionSheet: UIViewController {
         backgroundView.alpha = 0
         backgroundView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         backgroundView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
-        backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.removeActionSheet)))
+        backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self,
+                                                                   action: #selector(self.removeActionSheet)))
         return backgroundView
     }()
 
@@ -51,13 +54,15 @@ class VLCActionSheet: UIViewController {
     }()
 
     @objc lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: UIScreen.main.bounds, collectionViewLayout: collectionViewLayout)
+        let collectionView = UICollectionView(frame: UIScreen.main.bounds,
+                                              collectionViewLayout: collectionViewLayout)
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.backgroundColor = PresentationTheme.current.colors.background
         collectionView.alwaysBounceVertical = true
         collectionView.showsVerticalScrollIndicator = false
-        collectionView.register(VLCActionSheetCell.self, forCellWithReuseIdentifier: VLCActionSheetCell.identifier)
+        collectionView.register(VLCActionSheetCell.self,
+                                forCellWithReuseIdentifier: VLCActionSheetCell.identifier)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
@@ -130,7 +135,8 @@ class VLCActionSheet: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .VLCThemeDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme),
+                                               name: .VLCThemeDidChangeNotification, object: nil)
 
         view.addSubview(backgroundView)
         view.addSubview(mainStackView)
@@ -177,7 +183,8 @@ class VLCActionSheet: UIViewController {
         })
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize,
+                                     with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.maxCollectionViewHeightConstraint.constant = size.height / 2
@@ -246,7 +253,8 @@ private extension VLCActionSheet {
 
 private extension VLCActionSheet {
     private func setHeaderRoundedCorners() {
-        let roundedCornerPath = UIBezierPath(roundedRect: headerView.bounds, byRoundingCorners: [.topLeft, .topRight],
+        let roundedCornerPath = UIBezierPath(roundedRect: headerView.bounds,
+                                             byRoundingCorners: [.topLeft, .topRight],
                                              cornerRadii: CGSize(width: 10, height: 10))
         let maskLayer = CAShapeLayer()
         maskLayer.path = roundedCornerPath.cgPath
@@ -288,7 +296,9 @@ extension VLCActionSheet {
 // MARK: UICollectionViewDelegateFlowLayout
 
 extension VLCActionSheet: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: collectionView.frame.width, height: cellHeight)
     }
 }
@@ -296,7 +306,8 @@ extension VLCActionSheet: UICollectionViewDelegateFlowLayout {
 // MARK: UICollectionViewDelegate
 
 extension VLCActionSheet: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    func collectionView(_ collectionView: UICollectionView,
+                        didSelectItemAt indexPath: IndexPath) {
         if let delegate = delegate, let item = delegate.itemAtIndexPath(indexPath) {
             delegate.actionSheet?(collectionView: collectionView, didSelectItem: item, At: indexPath)
             action?(item)
@@ -308,16 +319,19 @@ extension VLCActionSheet: UICollectionViewDelegate {
 // MARK: UICollectionViewDataSource
 
 extension VLCActionSheet: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView,
+                        numberOfItemsInSection section: Int) -> Int {
         if let dataSource = dataSource {
             return dataSource.numberOfRows()
         }
         preconditionFailure("VLCActionSheet: No data source")
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    func collectionView(_ collectionView: UICollectionView,
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if let dataSource = dataSource {
-            return dataSource.actionSheet(collectionView: collectionView, cellForItemAt: indexPath)
+            return dataSource.actionSheet(collectionView: collectionView,
+                                          cellForItemAt: indexPath)
         }
         preconditionFailure("VLCActionSheet: No data source")
     }

--- a/Sources/VLCCloudSortingSpecifierManager.swift
+++ b/Sources/VLCCloudSortingSpecifierManager.swift
@@ -33,7 +33,7 @@ class VLCCloudSortingSpecifierManager: NSObject {
 
 // MARK: VLCActionSheetDelegate
 
-extension VLCCloudSortingSpecifierManager: VLCActionSheetDelegate {
+extension VLCCloudSortingSpecifierManager: ActionSheetDelegate {
     
     func headerViewTitle() -> String? {
         return NSLocalizedString("SORT_BY", comment: "")
@@ -51,7 +51,7 @@ extension VLCCloudSortingSpecifierManager: VLCActionSheetDelegate {
 
 // MARK: VLCActionSheetDataSource
 
-extension VLCCloudSortingSpecifierManager: VLCActionSheetDataSource {
+extension VLCCloudSortingSpecifierManager: ActionSheetDataSource {
     
     func numberOfRows() -> Int {
         return items.count

--- a/Sources/VLCRendererDiscovererManager.swift
+++ b/Sources/VLCRendererDiscovererManager.swift
@@ -19,8 +19,8 @@ class VLCRendererDiscovererManager: NSObject {
 
     @objc weak var delegate: VLCRendererDiscovererManagerDelegate?
 
-    @objc lazy var actionSheet: VLCActionSheet = {
-        let actionSheet = VLCActionSheet()
+    @objc lazy var actionSheet: ActionSheet = {
+        let actionSheet = ActionSheet()
         actionSheet.delegate = self
         actionSheet.dataSource = self
         actionSheet.modalPresentationStyle = .custom
@@ -187,7 +187,7 @@ extension VLCRendererDiscovererManager: VLCRendererDiscovererDelegate {
         }
     }
 
-    fileprivate func updateCollectionViewCellApparence(cell: VLCActionSheetCell, highlighted: Bool) {
+    fileprivate func updateCollectionViewCellApparence(cell: ActionSheetCell, highlighted: Bool) {
         var image = UIImage(named: "renderer")
         var textColor = PresentationTheme.current.colors.cellTextColor
         var tintColor = PresentationTheme.current.colors.cellDetailTextColor
@@ -206,7 +206,7 @@ extension VLCRendererDiscovererManager: VLCRendererDiscovererDelegate {
 
 // MARK: VLCActionSheetDelegate
 
-extension VLCRendererDiscovererManager: VLCActionSheetDelegate {
+extension VLCRendererDiscovererManager: ActionSheetDelegate {
     func headerViewTitle() -> String? {
         return NSLocalizedString("HEADER_TITLE_RENDERER", comment: "")
     }
@@ -222,7 +222,7 @@ extension VLCRendererDiscovererManager: VLCActionSheetDelegate {
 
     func actionSheet(collectionView: UICollectionView, didSelectItem item: Any, At indexPath: IndexPath) {
         guard let renderer = item as? VLCRendererItem,
-            let cell = collectionView.cellForItem(at: indexPath) as? VLCActionSheetCell else {
+            let cell = collectionView.cellForItem(at: indexPath) as? ActionSheetCell else {
             assertionFailure("VLCRendererDiscovererManager: VLCActionSheetDelegate: Cell is not a VLCActionSheetCell")
             return
         }
@@ -239,7 +239,7 @@ extension VLCRendererDiscovererManager: VLCActionSheetDelegate {
 
 // MARK: VLCActionSheetDataSource
 
-extension VLCRendererDiscovererManager: VLCActionSheetDataSource {
+extension VLCRendererDiscovererManager: ActionSheetDataSource {
     func numberOfRows() -> Int {
         return getAllRenderers().count
     }
@@ -247,7 +247,7 @@ extension VLCRendererDiscovererManager: VLCActionSheetDataSource {
     @discardableResult
     func actionSheet(collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: VLCActionSheetCell.identifier, for: indexPath) as? VLCActionSheetCell else {
+            withReuseIdentifier: ActionSheetCell.identifier, for: indexPath) as? ActionSheetCell else {
             assertionFailure("VLCRendererDiscovererManager: VLCActionSheetDataSource: Unable to dequeue reusable cell")
             return UICollectionViewCell()
         }

--- a/Sources/VLCSettingsSheetCell.swift
+++ b/Sources/VLCSettingsSheetCell.swift
@@ -10,7 +10,7 @@
  * Refer to the COPYING file of the official project for license.
  *****************************************************************************/
 
-class VLCSettingsSheetCell: VLCActionSheetCell {
+class VLCSettingsSheetCell: ActionSheetCell {
 
     override var isSelected: Bool {
         didSet {

--- a/Sources/VLCSettingsSpecifierManager.swift
+++ b/Sources/VLCSettingsSpecifierManager.swift
@@ -47,7 +47,7 @@ class VLCSettingsSpecifierManager: NSObject {
 
 // MARK: VLCActionSheetDelegate
 
-extension VLCSettingsSpecifierManager: VLCActionSheetDelegate {
+extension VLCSettingsSpecifierManager: ActionSheetDelegate {
     
     func headerViewTitle() -> String? {
         return specifier?.title()
@@ -65,7 +65,7 @@ extension VLCSettingsSpecifierManager: VLCActionSheetDelegate {
 
 // MARK: VLCActionSheetDataSource
 
-extension VLCSettingsSpecifierManager: VLCActionSheetDataSource {
+extension VLCSettingsSpecifierManager: ActionSheetDataSource {
     
     func numberOfRows() -> Int {
         return items.count

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -254,13 +254,13 @@
 		8D2AD4DA227AEE8E00393833 /* AddToPlaylistView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D2AD4D9227AEE8E00393833 /* AddToPlaylistView.xib */; };
 		8D3B4C0E2226E49A00B9F652 /* AudioMiniPlayer.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D3B4C0D2226E49A00B9F652 /* AudioMiniPlayer.xib */; };
 		8D43712D2056AF1600F36458 /* VLCRendererDiscovererManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D43712C2056AF1600F36458 /* VLCRendererDiscovererManager.swift */; };
-		8D437154205808FF00F36458 /* VLCActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D437153205808FF00F36458 /* VLCActionSheet.swift */; };
+		8D437154205808FF00F36458 /* ActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D437153205808FF00F36458 /* ActionSheet.swift */; };
 		8D4F9B472141630000E478BE /* MediaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4F9B462141630000E478BE /* MediaModel.swift */; };
 		8D66A47320AC61B900FA5B92 /* MediaLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D66A47220AC61B900FA5B92 /* MediaLibraryService.swift */; };
 		8D6E1588223BBAF600077DD3 /* MiniPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6E1587223BBAF600077DD3 /* MiniPlayer.swift */; };
 		8DD6516F208C89BC0052EE68 /* VLCAccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD6516E208C89BC0052EE68 /* VLCAccessibilityIdentifier.swift */; };
-		8DD651BA208F6AF00052EE68 /* VLCActionSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD651B9208F6AF00052EE68 /* VLCActionSheetCell.swift */; };
-		8DD651C4208F786F0052EE68 /* VLCActionSheetSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD651C3208F786F0052EE68 /* VLCActionSheetSectionHeader.swift */; };
+		8DD651BA208F6AF00052EE68 /* ActionSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD651B9208F6AF00052EE68 /* ActionSheetCell.swift */; };
+		8DD651C4208F786F0052EE68 /* ActionSheetSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD651C3208F786F0052EE68 /* ActionSheetSectionHeader.swift */; };
 		8DE187812105DAB100A091D2 /* VideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE187802105DAB100A091D2 /* VideoViewController.swift */; };
 		8DE187832105DB2E00A091D2 /* AudioViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE187822105DB2E00A091D2 /* AudioViewController.swift */; };
 		8DE1879A21060DBE00A091D2 /* MediaCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE1879921060DBE00A091D2 /* MediaCategory.swift */; };
@@ -828,13 +828,13 @@
 		8D2AD4D9227AEE8E00393833 /* AddToPlaylistView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddToPlaylistView.xib; sourceTree = "<group>"; };
 		8D3B4C0D2226E49A00B9F652 /* AudioMiniPlayer.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AudioMiniPlayer.xib; sourceTree = "<group>"; };
 		8D43712C2056AF1600F36458 /* VLCRendererDiscovererManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VLCRendererDiscovererManager.swift; path = Sources/VLCRendererDiscovererManager.swift; sourceTree = "<group>"; };
-		8D437153205808FF00F36458 /* VLCActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCActionSheet.swift; sourceTree = "<group>"; };
+		8D437153205808FF00F36458 /* ActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheet.swift; sourceTree = "<group>"; };
 		8D4F9B462141630000E478BE /* MediaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaModel.swift; sourceTree = "<group>"; };
 		8D66A47220AC61B900FA5B92 /* MediaLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryService.swift; sourceTree = "<group>"; };
 		8D6E1587223BBAF600077DD3 /* MiniPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayer.swift; sourceTree = "<group>"; };
 		8DD6516E208C89BC0052EE68 /* VLCAccessibilityIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCAccessibilityIdentifier.swift; sourceTree = "<group>"; };
-		8DD651B9208F6AF00052EE68 /* VLCActionSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCActionSheetCell.swift; sourceTree = "<group>"; };
-		8DD651C3208F786F0052EE68 /* VLCActionSheetSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCActionSheetSectionHeader.swift; sourceTree = "<group>"; };
+		8DD651B9208F6AF00052EE68 /* ActionSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetCell.swift; sourceTree = "<group>"; };
+		8DD651C3208F786F0052EE68 /* ActionSheetSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetSectionHeader.swift; sourceTree = "<group>"; };
 		8DE187802105DAB100A091D2 /* VideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoViewController.swift; sourceTree = "<group>"; };
 		8DE187822105DB2E00A091D2 /* AudioViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioViewController.swift; sourceTree = "<group>"; };
 		8DE1879921060DBE00A091D2 /* MediaCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCategory.swift; sourceTree = "<group>"; };
@@ -1291,7 +1291,7 @@
 				DDC10BE31AEE8EA700890DC3 /* VLCTimeNavigationTitleView.m */,
 				DD1CB0581BBAC549006EDDE6 /* VLCVolumeView.h */,
 				DD1CB0591BBAC549006EDDE6 /* VLCVolumeView.m */,
-				8DD651B0208F62B70052EE68 /* VLCActionSheet */,
+				8DD651B0208F62B70052EE68 /* ActionSheet */,
 				4144156920ECD2620078EC37 /* VLCSectionTableHeaderView.swift */,
 				4144156B20ECE6330078EC37 /* VLCFileServerView.swift */,
 				8D222DC120F779F1009C0D34 /* MediaEditCell.swift */,
@@ -1906,15 +1906,15 @@
 			path = Resources/Xib/MiniPlayer;
 			sourceTree = "<group>";
 		};
-		8DD651B0208F62B70052EE68 /* VLCActionSheet */ = {
+		8DD651B0208F62B70052EE68 /* ActionSheet */ = {
 			isa = PBXGroup;
 			children = (
-				8D437153205808FF00F36458 /* VLCActionSheet.swift */,
-				8DD651B9208F6AF00052EE68 /* VLCActionSheetCell.swift */,
-				8DD651C3208F786F0052EE68 /* VLCActionSheetSectionHeader.swift */,
+				8D437153205808FF00F36458 /* ActionSheet.swift */,
+				8DD651B9208F6AF00052EE68 /* ActionSheetCell.swift */,
+				8DD651C3208F786F0052EE68 /* ActionSheetSectionHeader.swift */,
 			);
-			name = VLCActionSheet;
-			path = Sources/VLCActionSheet;
+			name = ActionSheet;
+			path = Sources/ActionSheet;
 			sourceTree = "<group>";
 		};
 		8DE1877F2105DA2B00A091D2 /* MediaViewControllers */ = {
@@ -2963,7 +2963,7 @@
 				CAC7E3DE20F87BD000000751 /* VLCSettingsSpecifierManager.swift in Sources */,
 				7D37848F183A98B6009EE944 /* VLCMovieViewController.m in Sources */,
 				DD3EFF4D1BDEBCE500B68579 /* VLCNetworkServerBrowserPlex.m in Sources */,
-				8D437154205808FF00F36458 /* VLCActionSheet.swift in Sources */,
+				8D437154205808FF00F36458 /* ActionSheet.swift in Sources */,
 				DDF908E41CFCD97400108B70 /* VLCNetworkLoginDataSourceProtocol.m in Sources */,
 				41CF03E821D117D100B449E0 /* GenreCollectionViewCell.swift in Sources */,
 				8D66A47320AC61B900FA5B92 /* MediaLibraryService.swift in Sources */,
@@ -2977,7 +2977,7 @@
 				41EB91DD1F7BFF8500821AA5 /* VLCMetadata.m in Sources */,
 				41DFC6C62100BAAF00EEC9E3 /* VLCDocumentClass.swift in Sources */,
 				DD3EFF551BDEBCE500B68579 /* VLCLocalNetworkServiceBrowserDSM.m in Sources */,
-				8DD651C4208F786F0052EE68 /* VLCActionSheetSectionHeader.swift in Sources */,
+				8DD651C4208F786F0052EE68 /* ActionSheetSectionHeader.swift in Sources */,
 				7D37849E183A98DD009EE944 /* VLCThumbnailsCache.m in Sources */,
 				DD3EFF411BDEBCE500B68579 /* VLCNetworkServerBrowserSharedLibrary.m in Sources */,
 				418E88412110E51B00DDA6A7 /* URLHandler.swift in Sources */,
@@ -3014,7 +3014,7 @@
 				7D3784C8183A9972009EE944 /* NSString+SupportedMedia.m in Sources */,
 				417E68B91F321EFF00DB9BB2 /* VLCActivityViewControllerVendor.m in Sources */,
 				DD3EFF5B1BDEBCE500B68579 /* VLCNetworkServerBrowserUPnP.m in Sources */,
-				8DD651BA208F6AF00052EE68 /* VLCActionSheetCell.swift in Sources */,
+				8DD651BA208F6AF00052EE68 /* ActionSheetCell.swift in Sources */,
 				418B144D20179C75000447AA /* VLCTabBarCoordinator.swift in Sources */,
 				DD3EABF81BE14BD6003668DA /* BasicUPnPDevice+VLC.m in Sources */,
 				DD3EAC091BE2192A003668DA /* VLCServerBrowsingController.m in Sources */,


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This fixes the sort action sheet not showing up after a selection.
Also, a bit of name refactoring on the ActionSheet*.

Related ticket: https://code.videolan.org/videolan/vlc-ios/issues/438.
