### PR TITLE
MediaLibraryService: Artists: Set all to false by default

### DIFF
--- a/SharedSources/MediaLibraryService.swift
+++ b/SharedSources/MediaLibraryService.swift
@@ -323,8 +323,9 @@ extension MediaLibraryService {
 // MARK: - Audio methods
 
 @objc extension MediaLibraryService {
-    func artists(sortingCriteria sort: VLCMLSortingCriteria = .artist, desc: Bool = false) -> [VLCMLArtist] {
-        return medialib.artists(with: sort, desc: desc, all: true) ?? []
+    func artists(sortingCriteria sort: VLCMLSortingCriteria = .artist,
+                 desc: Bool = false, listAll all: Bool = false) -> [VLCMLArtist] {
+        return medialib.artists(with: sort, desc: desc, all: all) ?? []
     }
 
     func albums(sortingCriteria sort: VLCMLSortingCriteria = .album, desc: Bool = false) -> [VLCMLAlbum] {


### PR DESCRIPTION

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This fixes issue [#471](https://code.videolan.org/videolan/vlc-ios/issues/471).
As the documentation states:

``` 
 * @param includeAll If true, all artists including those without album
 *                   will be returned. If false, only artists which have
 *                   an album will be returned.
```
We now set `includeAll` to false. Ideally, as Hugo mentioned this could be a setting to add later on.

Sadly, this brings up another issue which is the artist discovery.
For example, when importing an album with multiple artist and featuring, this won't be taken into account directly leading to the issue we had before this patch.

A follow-up ticket should be open when this is merged.
