### PR TITLE
VLCMetaData: Populate lockscreen from mediaitem

### DIFF
--- a/SharedSources/VLCMetadata.h
+++ b/SharedSources/VLCMetadata.h
@@ -1,11 +1,15 @@
-//
-//  VLCMediaPlayer + Metadata.h
-//  VLC
-//
-//  Created by Carola Nitz on 9/27/17.
-//  Copyright © 2017 VideoLAN. All rights reserved.
-//
+/*****************************************************************************
+ * VLC for iOS
+ *****************************************************************************
+ * Copyright (c) 2017-2019 VideoLAN. All rights reserved.
+ * $Id$
+ *
+ * Authors: Carola Nitz <caro # videolan.org>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
 
+@class VLCMLMedia;
 @interface VLCMetaData: NSObject
 
 @property(readwrite, copy) NSString *title;
@@ -18,5 +22,9 @@
 @property(readwrite) NSNumber *elapsedPlaybackTime;
 @property(readwrite) NSNumber *playbackRate;
 
+#if TARGET_OS_IOS
+- (void)updateMetadataFromMedia:(VLCMLMedia *)media mediaPlayer:(VLCMediaPlayer*)mediaPlayer;
+#else
 - (void)updateMetadataFromMediaPlayer:(VLCMediaPlayer *)mediaPlayer;
+#endif
 @end

--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1077,7 +1077,12 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
     if (_needsMetadataUpdate == NO) {
         _needsMetadataUpdate = YES;
         dispatch_async(dispatch_get_main_queue(), ^{
+#if TARGET_OS_IOS
+            VLCMLMedia *media = self->_mediaPlayer.media ? [self->_delegate mediaForPlayingMedia:self->_mediaPlayer.media] : nil;
+            [self->_metadata updateMetadataFromMedia:media mediaPlayer:self->_mediaPlayer];
+#else
             [self->_metadata updateMetadataFromMediaPlayer:self->_mediaPlayer];
+#endif
             self->_needsMetadataUpdate = NO;
             [self recoverDisplayedMetadata];
         });


### PR DESCRIPTION
(fixes #469)

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
you have to test audio, video and random urls