### PR TITLE
fix image warnings

### DIFF
--- a/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Audio.imageset/Contents.json
+++ b/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Audio.imageset/Contents.json
@@ -7,12 +7,12 @@
     },
     {
       "idiom" : "universal",
-      "filename" : "Audio@2x.png",
+      "filename" : "audio@2x.png",
       "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "filename" : "Audio@3x.png",
+      "filename" : "audio@3x.png",
       "scale" : "3x"
     }
   ],

--- a/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Network.imageset/Contents.json
+++ b/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Network.imageset/Contents.json
@@ -7,12 +7,12 @@
     },
     {
       "idiom" : "universal",
-      "filename" : "Network@2x.png",
+      "filename" : "network@2x.png",
       "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "filename" : "Network@3x.png",
+      "filename" : "network@3x.png",
       "scale" : "3x"
     }
   ],

--- a/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Settings.imageset/Contents.json
+++ b/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Settings.imageset/Contents.json
@@ -7,12 +7,12 @@
     },
     {
       "idiom" : "universal",
-      "filename" : "Settings@2x.png",
+      "filename" : "settings@2x.png",
       "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "filename" : "Settings@3x.png",
+      "filename" : "settings@3x.png",
       "scale" : "3x"
     }
   ],

--- a/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Video.imageset/Contents.json
+++ b/vlc-ios/Images.xcassets/MenuNavigation/Tab bar/Video.imageset/Contents.json
@@ -7,12 +7,12 @@
     },
     {
       "idiom" : "universal",
-      "filename" : "Video@2x.png",
+      "filename" : "video@2x.png",
       "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "filename" : "Video@3x.png",
+      "filename" : "video@3x.png",
       "scale" : "3x"
     }
   ],


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
this fixes xcode warnings on systems with casesensitivity