### PR TITLE
MediaCollectionViewCell: Handle unknown and various artist

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ target 'VLC-iOS' do
   pod 'PAPasscode', '~>1.0'
   pod 'GoogleAPIClientForREST/Drive'
   pod 'MobileVLCKit', '3.3.2'
-  pod 'VLCMediaLibraryKit', '0.2.1'
+  pod 'VLCMediaLibraryKit', '0.2.2'
   pod 'MediaLibraryKit-prod'
   pod 'GTMAppAuth'
   pod 'OneDriveSDK'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
   - TVVLCKit (3.3.2)
   - upnpx (1.4.1)
   - VLC-WhiteRaccoon (1.0.0)
-  - VLCMediaLibraryKit (0.2.1):
+  - VLCMediaLibraryKit (0.2.2):
     - MobileVLCKit
   - XKKeychain (1.0.1)
   - xmlrpc (2.3.4):
@@ -103,7 +103,7 @@ DEPENDENCIES:
   - TVVLCKit (= 3.3.2)
   - upnpx (~> 1.4.0)
   - VLC-WhiteRaccoon
-  - VLCMediaLibraryKit (= 0.2.1)
+  - VLCMediaLibraryKit (= 0.2.2)
   - XKKeychain (~> 1.0)
 
 SPEC REPOS:
@@ -193,10 +193,10 @@ SPEC CHECKSUMS:
   TVVLCKit: dec91b12a8ae8a0031205279598a75993156cc65
   upnpx: f2a1b44c095b90e0a017ec0394e367053e78c31f
   VLC-WhiteRaccoon: 1e7e59b0568959135a89d09c416d1e11a5d9a986
-  VLCMediaLibraryKit: 24d54d6cc17cfc6a8481654d867651ab5579b279
+  VLCMediaLibraryKit: 5c2c3610c6a6e23fd03fecde44c61758467326a8
   XKKeychain: 852ef663c56a7194c73d3c68e8d9d4f07b121d4f
   xmlrpc: 109bb21d15ed6d108b2c1ac5973a6a223a50f5f4
 
-PODFILE CHECKSUM: e5e78c09efef8fd37d4347907dd711c5ad0c3460
+PODFILE CHECKSUM: a9496fc889a031267484a35723f442cfa23c0918
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.0

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -356,6 +356,8 @@
 
 "NO_SAVING_DATA" = "Nothing found";
 
-/* New strings */
+// MediaCollectionViewCell
+
 "UNKNOWN_ARTIST" = "Unknown Artist";
-"UNKNOWN_TITLE" = "Unknown Title";
+"VARIOUS_ARTIST" = "Various Artists";
+"UNKNOWN_ALBUM" = "Unknown Album";

--- a/SharedSources/MediaLibraryModel/AlbumModel.swift
+++ b/SharedSources/MediaLibraryModel/AlbumModel.swift
@@ -108,4 +108,24 @@ extension VLCMLAlbum {
         }
         return image
     }
+
+    func albumName() -> String {
+        return isUnknownAlbum() ? NSLocalizedString("UNKNOWN_ALBUM", comment: "") : title
+    }
+
+    func albumArtistName() -> String {
+        guard let artist = albumArtist else {
+            return NSLocalizedString("UNKNOWN_ARTIST", comment: "")
+        }
+        return artist.artistName()
+    }
+}
+
+extension VLCMLAlbumTrack {
+    func albumArtistName() -> String {
+        guard let artist = artist else {
+            return NSLocalizedString("UNKNOWN_ARTIST", comment: "")
+        }
+        return artist.artistName()
+    }
 }

--- a/SharedSources/MediaLibraryModel/ArtistModel.swift
+++ b/SharedSources/MediaLibraryModel/ArtistModel.swift
@@ -108,4 +108,14 @@ extension VLCMLArtist {
         }
         return image
     }
+
+    func artistName() -> String {
+        if identifier() == UnknownArtistID {
+            return NSLocalizedString("UNKNOWN_ARTIST", comment: "")
+        } else if identifier() == VariousArtistID {
+            return NSLocalizedString("VARIOUS_ARTIST", comment: "")
+        } else {
+            return name
+        }
+    }
 }

--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -156,3 +156,12 @@ extension VLCMLMedia {
         }
     }
 }
+
+extension VLCMLMedia {
+    func albumTrackArtistName() -> String {
+        guard let albumTrack = albumTrack else {
+            return NSLocalizedString("UNKNOWN_ARTIST", comment: "")
+        }
+        return albumTrack.albumArtistName()
+    }
+}

--- a/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MediaCollectionViewCell.swift
@@ -60,21 +60,21 @@ class MediaCollectionViewCell: BaseCollectionViewCell {
         thumbnailView.layer.masksToBounds = true
         thumbnailView.layer.cornerRadius = thumbnailView.frame.size.width / 2.0
         titleLabel.text = audiotrack.title
-        descriptionLabel.text = audiotrack.albumTrack?.artist?.name ?? NSLocalizedString("UNKNOWN_ARTIST", comment: "")
+        descriptionLabel.text = audiotrack.albumTrackArtistName()
         newLabel.isHidden = !audiotrack.isNew
         thumbnailView.image = audiotrack.thumbnailImage()
     }
 
     func update(album: VLCMLAlbum) {
-        titleLabel.text = album.title != "" ? album.title : NSLocalizedString("UNKNOWN_TITLE", comment: "")
-        descriptionLabel.text = album.albumArtist?.name != "" ? album.albumArtist?.name : NSLocalizedString("UNKNOWN_ARTIST", comment: "")
+        titleLabel.text = album.albumName()
+        descriptionLabel.text = album.albumArtistName()
         thumbnailView.image = album.thumbnail()
     }
 
     func update(artist: VLCMLArtist) {
         thumbnailView.layer.masksToBounds = true
         thumbnailView.layer.cornerRadius = thumbnailView.frame.size.width / 2.0
-        titleLabel.text = artist.name
+        titleLabel.text = artist.artistName()
         descriptionLabel.text = artist.numberOfTracksString()
         thumbnailView.image = artist.thumbnail()
     }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

In the medialibrary, there is a specific ID for unknown and various artist.

This uses them in order to show the correct localization for them.
