### PR TITLE
Disable passcode lock when no PIN is set

### DIFF
--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -157,6 +157,7 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
 - (void)PAPasscodeViewControllerDidCancel:(PAPasscodeViewController *)controller
 {
     [self updateForPasscode:nil];
+    [self.settingsStore setBool:false forKey:kVLCSettingPasscodeOnKey];
 }
 
 - (void)PAPasscodeViewControllerDidSetPasscode:(PAPasscodeViewController *)controller


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description

Just a minor issue that I found when using the passcode lock feature. (Issue [#513](https://code.videolan.org/videolan/vlc-ios/issues/513)).

btw... Great work with the new design of the App, it looks terrific with tabs.
