### PR TITLE
HTTP Import: Respect folder structure

### DIFF
--- a/Apple-TV/VLCRemotePlaybackViewController.m
+++ b/Apple-TV/VLCRemotePlaybackViewController.m
@@ -67,7 +67,7 @@
     self.discoveredFiles = [NSMutableArray array];
 
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    discoverer.directoryPath = [[searchPaths firstObject] stringByAppendingPathComponent:@"Upload"];
+    discoverer.directoryPath = [[searchPaths firstObject] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
     [discoverer addObserver:self];
     [discoverer startDiscovering];
 

--- a/Resources/web/jquery.fileupload.js
+++ b/Resources/web/jquery.fileupload.js
@@ -425,8 +425,7 @@
                                     that._isInstanceOf('Blob', file)) {
                                 formData.append(
                                     options.paramName[index] || paramName,
-                                    file,
-                                    file.name
+                                    file, file.path
                                 );
                             }
                         });

--- a/Sources/VLCConstants.h
+++ b/Sources/VLCConstants.h
@@ -75,6 +75,7 @@
 #define kVLCRecentURLTitles @"recent-url-titles"
 #define kVLCPrivateWebStreaming @"private-streaming"
 #define kVLChttpScanSubtitle @"http-scan-subtitle"
+#define kVLCHTTPUploadDirectory @"Upload"
 
 #define kSupportedFileExtensions @"\\.(3g2|3gp|3gp2|3gpp|amv|asf|avi|bik|bin|crf|divx|drc|dv|evo|f4v|flv|gvi|gxf|iso|m1v|m2v|m2t|m2ts|m4v|mkv|mov|mp2|mp2v|mp4|mp4v|mpe|mpeg|mpeg1|mpeg2|mpeg4|mpg|mpv2|mts|mtv|mxf|mxg|nsv|nuv|ogg|ogm|ogv|ogx|ps|rec|rm|rmvb|rpl|thp|tod|ts|tts|txd|vlc|vob|vro|webm|wm|wmv|wtv|xesc)$"
 #define kSupportedSubtitleFileExtensions @"\\.(cdg|idx|srt|sub|utf|ass|ssa|aqt|jss|psb|rt|smi|txt|smil|stl|usf|dks|pjs|mpl2|mks|vtt|ttml|dfxp)$"

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -622,7 +622,8 @@
 
     // create the path where to store the media temporarily
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *uploadDirPath = [searchPaths[0] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
+    NSString *uploadDirPath = [searchPaths.firstObject
+                               stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
     BOOL isDir = YES;

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -622,7 +622,7 @@
 
     // create the path where to store the media temporarily
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *uploadDirPath = [searchPaths[0] stringByAppendingPathComponent:@"Upload"];
+    NSString *uploadDirPath = [searchPaths[0] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
     BOOL isDir = YES;

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -612,7 +612,7 @@
      * check content disposition to find out filename */
 
     MultipartMessageHeaderField* disposition = (header.fields)[@"Content-Disposition"];
-    NSString* filename = [(disposition.params)[@"filename"] lastPathComponent];
+    NSString* filename = (disposition.params)[@"filename"];
 
     if ((nil == filename) || [filename isEqualToString: @""]) {
         // it's either not a file part, or
@@ -641,7 +641,8 @@
     }
 
     APLog(@"Saving file to %@", _filepath);
-    if (![fileManager createDirectoryAtPath:uploadDirPath withIntermediateDirectories:true attributes:nil error:nil])
+    if (![fileManager createDirectoryAtPath:[_filepath stringByDeletingLastPathComponent]
+                withIntermediateDirectories:true attributes:nil error:nil])
         APLog(@"Could not create directory at path: %@", _filepath);
 
     if (![fileManager createFileAtPath:_filepath contents:nil attributes:nil])

--- a/Sources/VLCHTTPFileDownloader.m
+++ b/Sources/VLCHTTPFileDownloader.m
@@ -150,7 +150,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
         [fileManager removeItemAtURL:downloadTask.fileURL error:nil];
 
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *basePath = [[searchPaths firstObject] stringByAppendingPathComponent:@"Upload"];
+    NSString *basePath = [[searchPaths firstObject] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
     downloadTask.fileName = [[newUrl lastPathComponent] stringByRemovingPercentEncoding];
     downloadTask.fileURL = [NSURL fileURLWithPath:[basePath stringByAppendingPathComponent:downloadTask.fileName]];
 

--- a/Sources/VLCHTTPUploaderController.m
+++ b/Sources/VLCHTTPUploaderController.m
@@ -305,7 +305,7 @@
     NSString *fileName = [filepath lastPathComponent];
     NSString *libraryPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
     NSString *uploadPath = [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)
-                            firstObject] stringByAppendingPathComponent:@"Upload"];
+                            firstObject] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
 
     NSString *finalFilePath = [libraryPath
                                stringByAppendingString:[filepath
@@ -359,7 +359,7 @@
         return;
 
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString* uploadDirPath = [searchPaths[0] stringByAppendingPathComponent:@"Upload"];
+    NSString* uploadDirPath = [searchPaths[0] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:uploadDirPath])
         [fileManager removeItemAtPath:uploadDirPath error:nil];

--- a/Sources/VLCHTTPUploaderController.m
+++ b/Sources/VLCHTTPUploaderController.m
@@ -359,7 +359,8 @@
         return;
 
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString* uploadDirPath = [searchPaths[0] stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
+    NSString *uploadDirPath = [searchPaths.firstObject
+                               stringByAppendingPathComponent:kVLCHTTPUploadDirectory];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:uploadDirPath])
         [fileManager removeItemAtPath:uploadDirPath error:nil];


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This might not be the ideal solution since I have a very limited knowledge on our HTTP-fun(JS, JQuery, ...) side.
With this patch, we now send the whole path in the `MultipartMessageHeader` which makes thinks easier on the application side to handle the file structure.

Testing are welcome!

Closes [#381](https://code.videolan.org/videolan/vlc-ios/issues/381) and partially avoids [medialibrary#74](https://code.videolan.org/videolan/medialibrary/issues/74).
