### PR TITLE
AudioViewController: Rearrange categories order

### DIFF
--- a/Sources/MediaViewControllers/AudioViewController.swift
+++ b/Sources/MediaViewControllers/AudioViewController.swift
@@ -27,10 +27,10 @@ class VLCAudioViewController: VLCMediaViewController {
 
     override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
         return [
-            VLCTrackCategoryViewController(services),
-            VLCGenreCategoryViewController(services),
             VLCArtistCategoryViewController(services),
             VLCAlbumCategoryViewController(services),
+            VLCTrackCategoryViewController(services),
+            VLCGenreCategoryViewController(services)
         ]
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->


To be in line with other platforms, set audio categories as:

Artist, Album, Tracks, Genre