### PR TITLE
VLCMediaViewController: Add long press to sort order

### DIFF
--- a/Sources/ActionSheet/ActionSheet.swift
+++ b/Sources/ActionSheet/ActionSheet.swift
@@ -70,7 +70,7 @@ class ActionSheet: UIViewController {
         return collectionView
     }()
 
-    private lazy var headerView: ActionSheetSectionHeader = {
+    private(set) lazy var headerView: ActionSheetSectionHeader = {
         let headerView = ActionSheetSectionHeader()
         headerView.title.text = delegate?.headerViewTitle?() ?? "Default header title"
         headerView.title.textColor = PresentationTheme.current.colors.cellTextColor

--- a/Sources/ActionSheet/ActionSheetSortSectionHeader.swift
+++ b/Sources/ActionSheet/ActionSheetSortSectionHeader.swift
@@ -18,7 +18,9 @@ class ActionSheetSortSectionHeader: ActionSheetSectionHeader {
         return 100
     }
 
-    let descendingStackView: UIStackView = {
+    private let sortModel: SortModel
+
+    private let descendingStackView: UIStackView = {
         let descendingStackView = UIStackView()
         descendingStackView.spacing = 0
         descendingStackView.alignment = .center
@@ -26,7 +28,7 @@ class ActionSheetSortSectionHeader: ActionSheetSectionHeader {
         return descendingStackView
     }()
 
-    let descendingLabel: UILabel = {
+    private let descendingLabel: UILabel = {
         let descendingLabel = UILabel()
         descendingLabel.textColor = PresentationTheme.current.colors.cellTextColor
         descendingLabel.text = NSLocalizedString("DESCENDING_LABEL", comment: "")
@@ -46,8 +48,10 @@ class ActionSheetSortSectionHeader: ActionSheetSectionHeader {
 
     weak var delegate: ActionSheetSortSectionHeaderDelegate?
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(model: SortModel) {
+        sortModel = model
+        super.init(frame: .zero)
+        actionSwitch.isOn = sortModel.desc
         translatesAutoresizingMaskIntoConstraints = false
         setupStackView()
         updateTheme()
@@ -55,6 +59,14 @@ class ActionSheetSortSectionHeader: ActionSheetSectionHeader {
                                                name: .VLCThemeDidChangeNotification, object: nil)
     }
 
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+
+        if newWindow != nil {
+            // ActionSheetSortSectionHeader did appear.
+            actionSwitch.isOn = sortModel.desc
+        }
+    }
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/Coordinators/SortModel.swift
+++ b/Sources/Coordinators/SortModel.swift
@@ -10,7 +10,7 @@
  * Refer to the COPYING file of the official project for license.
  *****************************************************************************/
 
-struct SortModel {
+class SortModel {
     var currentSort: VLCMLSortingCriteria
     var desc: Bool
     var sortingCriteria: [VLCMLSortingCriteria]

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -46,7 +46,7 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
 //    }()
 
     @objc private lazy var sortActionSheet: ActionSheet = {
-        let header = ActionSheetSortSectionHeader()
+        let header = ActionSheetSortSectionHeader(model: model.sortModel)
         let actionSheet = ActionSheet(header: header)
         header.delegate = self
         actionSheet.delegate = self
@@ -382,6 +382,10 @@ extension VLCMediaCategoryViewController {
                 IndexPath(row: currentSortIndex, section: 0), animated: false,
                                                     scrollPosition: .centeredVertically)
         }
+    }
+
+    func handleSortShortcut() {
+        model.sort(by: model.sortModel.currentSort, desc: !model.sortModel.desc)
     }
 }
 

--- a/Sources/MediaViewControllers/MediaViewController.swift
+++ b/Sources/MediaViewControllers/MediaViewController.swift
@@ -17,13 +17,21 @@ class VLCMediaViewController: VLCPagingViewController<VLCLabelCell>, MediaCatego
     var services: Services
     private var rendererButton: UIButton
     private lazy var sortButton: UIBarButtonItem = {
-        var sortButton = UIBarButtonItem(image: UIImage(named: "sort"),
-                                     style: .plain, target: self,
-                                     action: #selector(handleSort))
+        var sortButton = UIButton(frame: CGRect(x: 0, y: 0, width: 44, height: 44))
+        sortButton.setImage(UIImage(named: "sort"), for: .normal)
+        // It seems that using a custom view, UIBarButtonItem have a offset of 16, therefore adding a large margin
+        if UIView.userInterfaceLayoutDirection(for: sortButton.semanticContentAttribute) == .rightToLeft {
+            sortButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -16)
+        } else {
+            sortButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -16, bottom: 0, right: 0)
+        }
+        sortButton.addTarget(self, action: #selector(handleSort), for: .touchUpInside)
         sortButton.tintColor = PresentationTheme.current.colors.orangeUI
         sortButton.accessibilityLabel = NSLocalizedString("BUTTON_SORT", comment: "")
         sortButton.accessibilityHint = NSLocalizedString("BUTTON_SORT_HINT", comment: "")
-        return sortButton
+        sortButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self,
+                                                                     action: #selector(handleSortShortcut(sender:))))
+        return UIBarButtonItem(customView: sortButton)
     }()
 
     private lazy var editButton: UIBarButtonItem = {
@@ -128,6 +136,17 @@ extension VLCMediaViewController {
     @objc func handleSort() {
         if let mediaCategoryViewController = viewControllers[currentIndex] as? VLCMediaCategoryViewController {
             mediaCategoryViewController.handleSort()
+        }
+    }
+
+    @objc func handleSortShortcut(sender: UILongPressGestureRecognizer) {
+        if sender.state == .began {
+            if #available(iOS 10.0, *) {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }
+            if let mediaCategoryViewController = viewControllers[currentIndex] as? VLCMediaCategoryViewController {
+                mediaCategoryViewController.handleSortShortcut()
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This adds a nice small shortcut to change the sorting order.

After a discussion with Alex, I found this feature to be nice to have, so I decided to integrate it. 😅 