### PR TITLE
VLCPlaybackController: only restore playbackposition when less than 9…

### DIFF
--- a/Sources/VLCPlaybackController.m
+++ b/Sources/VLCPlaybackController.m
@@ -1096,7 +1096,8 @@ typedef NS_ENUM(NSUInteger, VLCAspectRatio) {
     if (!media) return;
 
     CGFloat lastPosition = media.progress;
-    if (_mediaPlayer.position < lastPosition) {
+    // .95 prevents the controller from opening and closing immediatly when restoring state
+    if (lastPosition < .95 && _mediaPlayer.position < lastPosition) {
         NSInteger continuePlayback;
         if (media.type == VLCMLMediaTypeAudio)
             continuePlayback = [[[NSUserDefaults standardUserDefaults] objectForKey:kVLCSettingContinueAudioPlayback] integerValue];


### PR DESCRIPTION
…5% were viewed

Otherwise a user might be unable to rewatch content because it would immediatly close the controller again

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
closes #522