### PR TITLE
MediaModels: Handle MediaModified callback

### DIFF
--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -35,6 +35,26 @@ extension MediaModel {
 
 // MARK: - Helpers
 
+extension MediaModel {
+    /// Swap the given [VLCMLMedia] to the cached array.
+    /// This only swaps media with the same VLCMLIdentifiers
+    /// - Parameter medias: To be swapped medias
+    /// - Returns: New array of `VLCMLMedia` if changes have been made, else return a unchanged cached version.
+    func swapMedias(with medias: [VLCMLMedia]) -> [VLCMLMedia] {
+        var newFiles = files
+
+        // FIXME: This should be handled in a thread safe way
+        for var media in medias {
+            for (currentMediaIndex, file) in files.enumerated()
+                where file.identifier() == media.identifier() {
+                    swap(&newFiles[currentMediaIndex], &media)
+                    break
+            }
+        }
+        return newFiles
+    }
+}
+
 extension VLCMLMedia {
     static func == (lhs: VLCMLMedia, rhs: VLCMLMedia) -> Bool {
         return lhs.identifier() == rhs.identifier()

--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -60,7 +60,9 @@ extension VLCMLMedia {
         return lhs.identifier() == rhs.identifier()
     }
 }
+
 // MARK: - ViewModel
+
 extension VLCMLMedia {
     @objc func mediaDuration() -> String {
         return String(format: "%@", VLCTime(int: Int32(duration())))

--- a/SharedSources/MediaLibraryModel/TrackModel.swift
+++ b/SharedSources/MediaLibraryModel/TrackModel.swift
@@ -60,6 +60,13 @@ extension TrackModel: MediaLibraryObserver {
         updateView?()
     }
 
+    func medialibrary(_ medialibrary: MediaLibraryService, didModifyTracks tracks: [VLCMLMedia]) {
+        if !tracks.isEmpty {
+            files = swapMedias(with: tracks)
+            updateView?()
+        }
+    }
+
     func medialibrary(_ medialibrary: MediaLibraryService, didDeleteMediaWithIds ids: [NSNumber]) {
         files = files.filter() {
             for id in ids where $0.identifier() == id.int64Value {

--- a/SharedSources/MediaLibraryModel/TrackModel.swift
+++ b/SharedSources/MediaLibraryModel/TrackModel.swift
@@ -55,8 +55,8 @@ extension TrackModel: EditableMLModel {
 // MARK: - MediaLibraryObserver
 
 extension TrackModel: MediaLibraryObserver {
-    func medialibrary(_ medialibrary: MediaLibraryService, didAddAudios audios: [VLCMLMedia]) {
-        audios.forEach({ append($0) })
+    func medialibrary(_ medialibrary: MediaLibraryService, didAddTracks tracks: [VLCMLMedia]) {
+        tracks.forEach({ append($0) })
         updateView?()
     }
 

--- a/SharedSources/MediaLibraryModel/VideoModel.swift
+++ b/SharedSources/MediaLibraryModel/VideoModel.swift
@@ -61,6 +61,13 @@ extension VideoModel: MediaLibraryObserver {
         updateView?()
     }
 
+    func medialibrary(_ medialibrary: MediaLibraryService, didModifyVideos videos: [VLCMLMedia]) {
+        if !videos.isEmpty {
+            files = swapMedias(with: videos)
+            updateView?()
+        }
+    }
+
     func medialibrary(_ medialibrary: MediaLibraryService, didDeleteMediaWithIds ids: [NSNumber]) {
         files = files.filter() {
             for id in ids where $0.identifier() == id.int64Value {

--- a/SharedSources/MediaLibraryService.swift
+++ b/SharedSources/MediaLibraryService.swift
@@ -25,8 +25,9 @@ extension NSNotification {
 
 @objc protocol MediaLibraryObserver: class {
     // Video
+
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
-                                     didModifyVideo video: [VLCMLMedia])
+                                     didModifyVideos videos: [VLCMLMedia])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteMediaWithIds ids: [NSNumber])
@@ -45,13 +46,22 @@ extension NSNotification {
                                      didAddTracks tracks: [VLCMLMedia])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
+                                     didModifyTracks tracks: [VLCMLMedia])
+
+    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddArtists artists: [VLCMLArtist])
+
+    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
+                                     didModifyArtists artists: [VLCMLArtist])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteArtistsWithIds artistsIds: [NSNumber])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddAlbums albums: [VLCMLAlbum])
+
+    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
+                                     didModifyAlbums albums: [VLCMLAlbum])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteAlbumsWithIds albumsIds: [NSNumber])
@@ -61,6 +71,9 @@ extension NSNotification {
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddGenres genres: [VLCMLGenre])
+
+    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
+                                     didModifyGenres genres: [VLCMLGenre])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteGenresWithIds genreIds: [NSNumber])
@@ -431,10 +444,15 @@ extension MediaLibraryService: VLCMediaLibraryDelegate {
 
         let showEpisodes = media.filter {( $0.subtype() == .showEpisode )}
         let albumTrack = media.filter {( $0.subtype() == .albumTrack )}
+        let videos = media.filter {( $0.type() == .video)}
+        let tracks = media.filter {( $0.type() == .audio)}
 
+        // Shows and albumtracks are known only after when the medialibrary calls didModifyMedia
         for observer in observers {
             observer.value.observer?.medialibrary?(self, didAddShowEpisodes: showEpisodes)
             observer.value.observer?.medialibrary?(self, didAddAlbumTracks: albumTrack)
+            observer.value.observer?.medialibrary?(self, didModifyVideos: videos)
+            observer.value.observer?.medialibrary?(self, didModifyTracks: tracks)
         }
     }
 
@@ -465,6 +483,12 @@ extension MediaLibraryService {
         }
     }
 
+    func medialibrary(_ medialibrary: VLCMediaLibrary, didModifyArtists artists: [VLCMLArtist]) {
+        for observer in observers {
+            observer.value.observer?.medialibrary?(self, didModifyArtists: artists)
+        }
+    }
+
     func medialibrary(_ medialibrary: VLCMediaLibrary, didDeleteArtistsWithIds artistsIds: [NSNumber]) {
         for observer in observers {
             observer.value.observer?.medialibrary?(self, didDeleteArtistsWithIds: artistsIds)
@@ -481,9 +505,37 @@ extension MediaLibraryService {
         }
     }
 
+    func medialibrary(_ medialibrary: VLCMediaLibrary, didModify albums: [VLCMLAlbum]) {
+        for observer in observers {
+            observer.value.observer?.medialibrary?(self, didAddAlbums: albums)
+        }
+    }
+
     func medialibrary(_ medialibrary: VLCMediaLibrary, didDeleteAlbumsWithIds albumsIds: [NSNumber]) {
         for observer in observers {
             observer.value.observer?.medialibrary?(self, didDeleteAlbumsWithIds: albumsIds)
+        }
+    }
+}
+
+// MARK: - VLCMediaLibraryDelegate - Genres
+extension MediaLibraryService {
+    func medialibrary(_ medialibrary: VLCMediaLibrary, didAdd genres: [VLCMLGenre]) {
+        for observer in observers {
+            observer.value.observer?.medialibrary?(self, didAddGenres: genres)
+        }
+    }
+
+    func medialibrary(_ medialibrary: VLCMediaLibrary, didModifyGenres genres: [VLCMLGenre]) {
+        for observer in observers {
+            observer.value.observer?.medialibrary?(self, didModifyGenres: genres)
+        }
+    }
+
+    func medialibrary(_ medialibrary: VLCMediaLibrary,
+                      didDeleteGenresWithIds genresIds: [NSNumber]) {
+        for observer in observers {
+            observer.value.observer?.medialibrary?(self, didDeleteGenresWithIds: genresIds)
         }
     }
 }

--- a/SharedSources/MediaLibraryService.swift
+++ b/SharedSources/MediaLibraryService.swift
@@ -25,6 +25,8 @@ extension NSNotification {
 
 @objc protocol MediaLibraryObserver: class {
     // Video
+    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
+                                     didAddVideos videos: [VLCMLMedia])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didModifyVideos videos: [VLCMLMedia])
@@ -32,22 +34,22 @@ extension NSNotification {
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteMediaWithIds ids: [NSNumber])
 
-    @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
-                                     didAddVideos videos: [VLCMLMedia])
-
+    // ShowEpisodes
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddShowEpisodes showEpisodes: [VLCMLMedia])
 
+    // Tumbnail
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      thumbnailReady media: VLCMLMedia)
 
-    // Audio
+    // Tracks
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddTracks tracks: [VLCMLMedia])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didModifyTracks tracks: [VLCMLMedia])
 
+    // Artists
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddArtists artists: [VLCMLArtist])
 
@@ -57,6 +59,7 @@ extension NSNotification {
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteArtistsWithIds artistsIds: [NSNumber])
 
+    // Albums
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddAlbums albums: [VLCMLAlbum])
 
@@ -66,9 +69,11 @@ extension NSNotification {
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didDeleteAlbumsWithIds albumsIds: [NSNumber])
 
+    // AlbumTracks
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddAlbumTracks albumTracks: [VLCMLMedia])
 
+    // Genres
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddGenres genres: [VLCMLGenre])
 

--- a/SharedSources/MediaLibraryService.swift
+++ b/SharedSources/MediaLibraryService.swift
@@ -42,7 +42,7 @@ extension NSNotification {
 
     // Audio
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
-                                     didAddAudios audios: [VLCMLMedia])
+                                     didAddTracks tracks: [VLCMLMedia])
 
     @objc optional func medialibrary(_ medialibrary: MediaLibraryService,
                                      didAddArtists artists: [VLCMLArtist])
@@ -414,14 +414,14 @@ extension MediaLibraryService: VLCMediaLibraryDelegate {
         media.forEach { $0.updateCoreSpotlightEntry() }
 
         let videos = media.filter {( $0.type() == .video )}
-        let audio = media.filter {( $0.type() == .audio )}
+        let tracks = media.filter {( $0.type() == .audio )}
 
         // thumbnails only for videos
         requestThumbnail(for: videos)
 
         for observer in observers {
             observer.value.observer?.medialibrary?(self, didAddVideos: videos)
-            observer.value.observer?.medialibrary?(self, didAddAudios: audio)
+            observer.value.observer?.medialibrary?(self, didAddTracks: tracks)
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

First, this adds the medialibrary object modified callbacks to the `MediaLibraryService`.
Secondly, this integrates the modified callbacks to the MediaModels(Video, Tracks) since for now, we only expose the ability to change metadata to MediaModels.
Additionally, some minor cosmetic/readability patches.
