### PR TITLE
VLCDropboxController: Re-integrate currentListFiles

### DIFF
--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -223,6 +223,11 @@
     }];
 }
 
+- (NSArray *)currentListFiles
+{
+    return _currentFileList;
+}
+
 - (void)downloadFileFrom:(NSString *)path to:(NSString *)destination
 {
     if (![self _supportedFileExtension:[path lastPathComponent]]) {


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
It seems that this was removed by 3a9b4d86.

Without this method, we are never getting the file listing.
