### PR TITLE
AppCoordinator: Fix invisible 6th tab in TabBar

### DIFF
--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -21,14 +21,15 @@ class Services: NSObject {
     private var childCoordinators: [NSObject] = []
     private var playerController: VLCPlayerDisplayController
     private var tabBarController: UITabBarController
-    private var tabBarCoordinator: VLCTabBarCoordinator
+    private lazy var tabBarCoordinator: VLCTabBarCoordinator = {
+        return VLCTabBarCoordinator(tabBarController: tabBarController, services: services)
+    }()
     private var migrationViewController = VLCMigrationViewController(nibName: String(describing: VLCMigrationViewController.self),
                                                                      bundle: nil)
 
     @objc init(tabBarController: UITabBarController) {
         self.playerController = VLCPlayerDisplayController(services: services)
         self.tabBarController = tabBarController
-        tabBarCoordinator = VLCTabBarCoordinator(tabBarController: tabBarController, services: services)
         super.init()
         setupChildViewControllers()
 


### PR DESCRIPTION
initializing the tabbarcoordinator before we setup the childViewControllers leads to a 6th tab
Likely caused by tabBarController.addChild(playerController) which contains our miniplayer

instantiating the tabbarcoordinator lazily fixes it
(closes #539)

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
