### PR TITLE
VLCMediaCategoryViewController: correctly size cells

### DIFF
--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -159,6 +159,8 @@ class VLCMediaCategoryViewController: UICollectionViewController, UICollectionVi
             manager.start()
         }
         manager.presentingViewController = self
+        cachedCellSize = .zero
+        collectionView.collectionViewLayout.invalidateLayout()
     }
 
     @objc func themeDidChange() {


### PR DESCRIPTION
When we turn the device while watching a movie we don't get the safeareas did change event
the calculation was therefor based on a wrong width. Relayouting in viewwillAppear fixes this issue

(closes #524)

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
