### PR TITLE
MovieCollectionViewCell: Adjust height

### DIFF
--- a/Sources/MediaCategoryCells/MovieCollectionViewCell.swift
+++ b/Sources/MediaCategoryCells/MovieCollectionViewCell.swift
@@ -99,8 +99,8 @@ class MovieCollectionViewCell: BaseCollectionViewCell {
         let overallCellWidthWithoutPadding = overallWidth - (numberOfCells + 1) * interItemPadding
         let cellWidth = floor(overallCellWidthWithoutPadding / numberOfCells)
 
-        // 3*20 for the labels + 24 for 3*8 which is the padding
-        return CGSize(width: cellWidth, height: cellWidth * aspectRatio + 3*20+24)
+        // 17 * 2 for title, 14 for new + duration, 3 * 4 paddings for lines
+        return CGSize(width: cellWidth, height: cellWidth * aspectRatio + (17 * 2) + 14 + (3 * 4))
     }
 
     override func prepareForReuse() {

--- a/Sources/MediaCategoryCells/MovieCollectionViewCell.xib
+++ b/Sources/MediaCategoryCells/MovieCollectionViewCell.xib
@@ -29,25 +29,25 @@
                                     <constraint firstAttribute="width" secondItem="jmi-G0-XOo" secondAttribute="height" multiplier="16:10" id="Oml-o7-Dfl"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4zQ-Mf-dw7" userLabel="Titlelabel">
-                                <rect key="frame" x="0.0" y="201" width="37.5" height="7.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4zQ-Mf-dw7" userLabel="Titlelabel">
+                                <rect key="frame" x="0.0" y="201" width="35.5" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                                 <size key="shadowOffset" width="0.0" height="0.0"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cgk-mu-ntx">
-                                <rect key="frame" x="0.0" y="216.5" width="61" height="13.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cgk-mu-ntx">
+                                <rect key="frame" x="0.0" y="226" width="61" height="4"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="new" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aby-eq-q1j" userLabel="NewLabel">
-                                        <rect key="frame" x="0.0" y="0.0" width="23" height="13.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="23" height="4"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                         <size key="shadowOffset" width="0.0" height="0.0"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oac-dS-Qcd" userLabel="descriptionLabel">
-                                        <rect key="frame" x="31" y="0.0" width="30" height="13.5"/>
+                                        <rect key="frame" x="31" y="0.0" width="30" height="4"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This adjusts the height for **MovieCollectionViewCells** by:

- Removing extra 24 padding
- Increasing compression resistance of the title label
- Decrease title to 14

Tests are welcome, I have tested this on:

- iPhone 4s - iOS 9
- iPhone 8 - iOS 12
- iPhone X - iOS 12
- iPad Pro (12.9) 3rd gen - iOS 12

**Comparaison screenshots:**

Left with new changes - right master.

![compariri](https://i.gyazo.com/c61a96ae16b05c952a88f55b3b61c9e7.jpg)

With long titles
![compariri2](https://i.gyazo.com/fe17ff43b068e2b2463d6a6a14084dc9.png)