### PR TITLE
VLCMetadata: Show data in Miniplayer even when passcode is enabled

### DIFF
--- a/SharedSources/VLCMetadata.m
+++ b/SharedSources/VLCMetadata.m
@@ -43,7 +43,6 @@
 #if TARGET_OS_IOS
 - (void)updateMetadataFromMedia:(VLCMLMedia *)media mediaPlayer:(VLCMediaPlayer*)mediaPlayer
 {
-    if ([VLCKeychainCoordinator passcodeLockEnabled]) return;
     if (media) {
         self.title = media.title;
         self.artist = media.albumTrack.artist.name;
@@ -60,6 +59,9 @@
         self.title = [[mediaPlayer.media url] lastPathComponent];
     }
     [self updatePlaybackRate:mediaPlayer];
+
+    //Down here because we still need to populate the miniplayer
+    if ([VLCKeychainCoordinator passcodeLockEnabled]) return;
 
     [self populateInfoCenterFromMetadata];
 }


### PR DESCRIPTION
Before we would immediatly return, now we return before populating the
infocenter

closes #511

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
