### PR TITLE
CollectionModel: Fix deletion for VLCMLMedias

### DIFF
--- a/SharedSources/MediaLibraryModel/CollectionModel.swift
+++ b/SharedSources/MediaLibraryModel/CollectionModel.swift
@@ -46,6 +46,18 @@ class CollectionModel: MLBaseModel {
                     playlist.removeMedia(fromPosition: UInt32(index))
                 }
             }
+        } else {
+            do {
+                for case let media as VLCMLMedia in items {
+                    if let mainFile = media.mainFile() {
+                        try FileManager.default.removeItem(atPath: mainFile.mrl.path)
+                    }
+                }
+                medialibrary.reload()
+            }
+            catch let error as NSError {
+                assertionFailure("CollectionModel: Delete failed: \(error.localizedDescription)")
+            }
         }
     }
 }
@@ -64,6 +76,11 @@ extension CollectionModel: MediaLibraryObserver {
             files = mediaCollection.files() ?? []
             updateView?()
         }
+    }
+
+    func medialibrary(_ medialibrary: MediaLibraryService, didDeleteMediaWithIds ids: [NSNumber]) {
+        files = mediaCollection.files() ?? []
+        updateView?()
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This fixes the deletion on collections such as Artist, Albums.
