### PR TITLE
UINavigationBar: iOS 13 requires standard and scrollEdgeApperance to …

### DIFF
--- a/Sources/AppearanceManager.swift
+++ b/Sources/AppearanceManager.swift
@@ -27,12 +27,12 @@ class AppearanceManager: NSObject {
         UINavigationBar.appearance().barTintColor = theme.colors.navigationbarColor
         UINavigationBar.appearance(whenContainedInInstancesOf: [VLCPlaybackNavigationController.self]).barTintColor = nil
         UINavigationBar.appearance().tintColor = theme.colors.orangeUI
-        UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: theme.colors.navigationbarTextColor]
+        UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: theme.colors.navigationbarTextColor]
 
         if #available(iOS 11.0, *) {
             UINavigationBar.appearance().prefersLargeTitles = true
             UINavigationBar.appearance(whenContainedInInstancesOf: [VLCPlaybackNavigationController.self]).prefersLargeTitles = false
-            UINavigationBar.appearance().largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: theme.colors.navigationbarTextColor]
+            UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: theme.colors.navigationbarTextColor]
         }
         // For the edit selection indicators
         UITableView.appearance().tintColor = theme.colors.orangeUI
@@ -45,6 +45,15 @@ class AppearanceManager: NSObject {
         UIPageControl.appearance().backgroundColor = theme.colors.background
         UIPageControl.appearance().pageIndicatorTintColor = .lightGray
         UIPageControl.appearance().currentPageIndicatorTintColor = theme.colors.orangeUI
+    }
+
+    @available(iOS 13.0, *)
+    @objc class func navigationbarAppearance() -> UINavigationBarAppearance {
+        let navBarAppearance = UINavigationBarAppearance()
+        navBarAppearance.backgroundColor = PresentationTheme.current.colors.navigationbarColor
+        navBarAppearance.titleTextAttributes = [.foregroundColor: PresentationTheme.current.colors.navigationbarTextColor]
+        navBarAppearance.largeTitleTextAttributes = [.foregroundColor: PresentationTheme.current.colors.navigationbarTextColor]
+        return navBarAppearance
     }
 }
 

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
@@ -68,6 +68,10 @@
     self.dataSource = dataSource;
 
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"BUTTON_CONNECT", nil) style:UIBarButtonItemStyleDone target:self action:@selector(connectLoginDataSource)];
+    if (@available(iOS 13.0, *)) {
+        self.navigationController.navigationBar.standardAppearance = [VLCApperanceManager navigationbarAppearance];
+        self.navigationController.navigationBar.scrollEdgeAppearance = [VLCApperanceManager navigationbarAppearance];
+    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle

--- a/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
@@ -168,7 +168,7 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(themeDidChange) name:kVLCThemeDidChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeDidChange) name:UIContentSizeCategoryDidChangeNotification object:nil];
-
+    [self themeDidChange];
     NSArray *browserClasses = @[
                                 [VLCLocalNetworkServiceBrowserUPnP class],
                                 [VLCLocalNetworkServiceBrowserPlex class],
@@ -336,6 +336,10 @@
     _localNetworkTableView.separatorColor = PresentationTheme.current.colors.background;
     _refreshControl.backgroundColor = PresentationTheme.current.colors.background;
     self.navigationController.view.backgroundColor = PresentationTheme.current.colors.background;
+    if (@available(iOS 13.0, *)) {
+        self.navigationController.navigationBar.standardAppearance = [VLCApperanceManager navigationbarAppearance];
+        self.navigationController.navigationBar.scrollEdgeAppearance = [VLCApperanceManager navigationbarAppearance];
+    }
     [self setNeedsStatusBarAppearanceUpdate];
 }
 

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -335,7 +335,7 @@ extension MediaCategoryViewController {
         searchDataSource.shouldReloadFor(searchString: searchText)
         reloadData()
         if searchText.isEmpty {
-            self.searchBar.resignFirstResponder
+            self.searchBar.resignFirstResponder()
         }
     }
 }

--- a/Sources/VLCFirstStepsViewController.m
+++ b/Sources/VLCFirstStepsViewController.m
@@ -69,6 +69,10 @@
 - (void)updateTheme
 {
     self.view.backgroundColor = PresentationTheme.current.colors.background;
+    if (@available(iOS 13.0, *)) {
+        self.navigationController.navigationBar.standardAppearance = [VLCApperanceManager navigationbarAppearance];
+        self.navigationController.navigationBar.scrollEdgeAppearance = [VLCApperanceManager navigationbarAppearance];
+    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle

--- a/Sources/VLCTabBarCoordinator.swift
+++ b/Sources/VLCTabBarCoordinator.swift
@@ -37,11 +37,14 @@ class VLCTabBarCoordinator: NSObject {
             if let navController = $0 as? UINavigationController, navController.topViewController is VLCSettingsController {
                 navController.navigationBar.barTintColor = PresentationTheme.current.colors.navigationbarColor
                 navController.navigationBar.tintColor = PresentationTheme.current.colors.orangeUI
-                navController.navigationBar.isTranslucent = false
                 navController.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
 
                 if #available(iOS 11.0, *) {
                     navController.navigationBar.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
+                }
+                if #available(iOS 13.0, *) {
+                    navController.navigationBar.standardAppearance = AppearanceManager.navigationbarAppearance()
+                    navController.navigationBar.scrollEdgeAppearance = AppearanceManager.navigationbarAppearance()
                 }
             }
         }


### PR DESCRIPTION
…be set

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

this fixes  translucent navigationbars on iOS 13: 
![Simulator Screen Shot - iPhone Xs - 2019-08-08 at 16 23 03](https://user-images.githubusercontent.com/2445653/62711167-d9e1e980-b9f8-11e9-8207-63917b8a8383.png)
![Simulator Screen Shot - iPhone Xs - 2019-08-08 at 16 23 00](https://user-images.githubusercontent.com/2445653/62711174-dcdcda00-b9f8-11e9-9651-3102e860565a.png)


### Description
<!-- Describe your changes in detail -->
