### PR TITLE
Dropbox: Handle login cancel case correctly

### DIFF
--- a/Sources/URLHandler.swift
+++ b/Sources/URLHandler.swift
@@ -34,6 +34,14 @@ import Foundation
 class DropBoxURLHandler: NSObject, VLCURLHandler {
 
     @objc func canHandleOpen(url: URL, options: [UIApplication.OpenURLOptionsKey: AnyObject]) -> Bool {
+
+        let components = url.pathComponents
+        let methodName = components.count > 1 ? components[1] : nil
+
+        if methodName == "cancel" {
+            return false
+        }
+
         return url.scheme == "db-a60fc6qj9zdg7bw"
     }
 

--- a/Sources/URLHandler.swift
+++ b/Sources/URLHandler.swift
@@ -191,7 +191,11 @@ public class VLCCallbackURLHandler: NSObject, VLCURLHandler {
 
 class ElseCallbackURLHandler: NSObject, VLCURLHandler {
     @objc func canHandleOpen(url: URL, options: [UIApplication.OpenURLOptionsKey: AnyObject]) -> Bool {
-        return true
+        guard let scheme = url.scheme else {
+            return false
+        }
+        return scheme.range(of: kSupportedProtocolSchemes,
+                            options: [.regularExpression, .caseInsensitive], range: nil, locale: nil) != nil
     }
 
     func performOpen(url: URL, options: [UIApplication.OpenURLOptionsKey: AnyObject]) -> Bool {

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -179,7 +179,7 @@ didFailToContinueUserActivityWithType:(NSString *)userActivityType
     for (id<VLCURLHandler> handler in URLHandlers.handlers) {
         if ([handler canHandleOpenWithUrl:url options:options]) {
             if ([handler performOpenWithUrl:url options:options]) {
-                break;
+                return YES;
             }
         }
     }

--- a/Sources/VLCConstants.h
+++ b/Sources/VLCConstants.h
@@ -83,6 +83,8 @@
 #define kSupportedAudioFileExtensions @"\\.(3ga|669|a52|aac|ac3|adt|adts|aif|aifc|aiff|amb|amr|aob|ape|au|awb|caf|dts|flac|it|kar|m4a|m4b|m4p|m5p|mid|mka|mlp|mod|mpa|mp1|mp2|mp3|mpc|mpga|mus|oga|ogg|oma|opus|qcp|ra|rmi|s3m|sid|spx|tak|thd|tta|voc|vqf|w64|wav|wma|wv|xa|xm)$"
 #define kSupportedPlaylistFileExtensions @"\\.(asx|b4s|cue|ifo|m3u|m3u8|pls|ram|rar|sdp|vlc|xspf|wax|wvx|zip|conf)$"
 
+#define kSupportedProtocolSchemes @"(rtsp|mms|mmsh|udp|rtp|rtmp|sftp|ftp|smb)$"
+
 #define kVLCDarwinNotificationNowPlayingInfoUpdate @"org.videolan.ios-app.nowPlayingInfoUpdate"
 
 #if TARGET_IPHONE_SIMULATOR


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

In the case where the user would cancel the login of Dropbox, we were launching the media player.