### PR TITLE
GenreModel: Observe didModifyGenres

### DIFF
--- a/SharedSources/MediaLibraryModel/GenreModel.swift
+++ b/SharedSources/MediaLibraryModel/GenreModel.swift
@@ -47,6 +47,11 @@ extension GenreModel: MediaLibraryObserver {
         updateView?()
     }
 
+    func medialibrary(_ medialibrary: MediaLibraryService, didModifyGenres genres: [VLCMLGenre]) {
+        files = swapModels(with: genres)
+        updateView?()
+    }
+
     func medialibrary(_ medialibrary: MediaLibraryService, didDeleteGenresWithIds genreIds: [NSNumber]) {
         files.removeAll {
             genreIds.contains(NSNumber(value: $0.identifier()))

--- a/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaLibraryBaseModel.swift
@@ -77,3 +77,31 @@ protocol MediaCollectionModel {
     func sortModel() -> SortModel?
     func title() -> String?
 }
+
+// MARK: - Helper methods
+
+extension MLBaseModel {
+    /// Swap the given [MLType] to the cached array.
+    /// This only swaps models with the same VLCMLIdentifiers
+    /// - Parameter models: To be swapped models
+    /// - Returns: New array of `MLType` if changes have been made, else return a unchanged cached version.
+    func swapModels(with models: [MLType]) -> [MLType] {
+        var newFiles = files
+
+        // FIXME: This should be handled in a thread safe way
+        for var model in models {
+            for (currentMediaIndex, file) in files.enumerated()
+                where file.identifier() == model.identifier() {
+                    swap(&newFiles[currentMediaIndex], &model)
+                    break
+            }
+        }
+        return newFiles
+    }
+}
+
+extension VLCMLObject {
+    static func == (lhs: VLCMLObject, rhs: VLCMLObject) -> Bool {
+        return lhs.identifier() == rhs.identifier()
+    }
+}

--- a/SharedSources/MediaLibraryModel/MediaModel.swift
+++ b/SharedSources/MediaLibraryModel/MediaModel.swift
@@ -33,34 +33,6 @@ extension MediaModel {
     }
 }
 
-// MARK: - Helpers
-
-extension MediaModel {
-    /// Swap the given [VLCMLMedia] to the cached array.
-    /// This only swaps media with the same VLCMLIdentifiers
-    /// - Parameter medias: To be swapped medias
-    /// - Returns: New array of `VLCMLMedia` if changes have been made, else return a unchanged cached version.
-    func swapMedias(with medias: [VLCMLMedia]) -> [VLCMLMedia] {
-        var newFiles = files
-
-        // FIXME: This should be handled in a thread safe way
-        for var media in medias {
-            for (currentMediaIndex, file) in files.enumerated()
-                where file.identifier() == media.identifier() {
-                    swap(&newFiles[currentMediaIndex], &media)
-                    break
-            }
-        }
-        return newFiles
-    }
-}
-
-extension VLCMLMedia {
-    static func == (lhs: VLCMLMedia, rhs: VLCMLMedia) -> Bool {
-        return lhs.identifier() == rhs.identifier()
-    }
-}
-
 // MARK: - ViewModel
 
 extension VLCMLMedia {

--- a/SharedSources/MediaLibraryModel/TrackModel.swift
+++ b/SharedSources/MediaLibraryModel/TrackModel.swift
@@ -62,7 +62,7 @@ extension TrackModel: MediaLibraryObserver {
 
     func medialibrary(_ medialibrary: MediaLibraryService, didModifyTracks tracks: [VLCMLMedia]) {
         if !tracks.isEmpty {
-            files = swapMedias(with: tracks)
+            files = swapModels(with: tracks)
             updateView?()
         }
     }

--- a/SharedSources/MediaLibraryModel/VideoModel.swift
+++ b/SharedSources/MediaLibraryModel/VideoModel.swift
@@ -62,7 +62,7 @@ extension VideoModel: MediaLibraryObserver {
 
     func medialibrary(_ medialibrary: MediaLibraryService, didModifyVideos videos: [VLCMLMedia]) {
         if !videos.isEmpty {
-            files = swapMedias(with: videos)
+            files = swapModels(with: videos)
             updateView?()
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

This fixes the case where Genres were not updated on modification.

For now this fixes only addition since media deletion doesn't seem to be triggering didModifyGenres.

Depending on the medialibrary schedule, a workaround might be needed.