### PR TITLE
(WIP) MediaMoreOptionsActionSheet: Present PlaybackSpeedView on playback selection

### DIFF
--- a/Sources/ActionSheet/MediaMoreOptionsActionSheet.swift
+++ b/Sources/ActionSheet/MediaMoreOptionsActionSheet.swift
@@ -84,6 +84,15 @@ extension MediaMoreOptionsActionSheet: MediaPlayerActionSheetDataSource {
             if $0 == .interfaceLock {
                 cellModel.accessoryType = .toggleSwitch
                 cellModel.viewToPresent = nil
+            } else if $0 == .playback {
+                if let playbackView = Bundle.main.loadNibNamed("PlaybackSpeedView", owner: self, options: nil)?.first
+                    as? PlaybackSpeedView {
+                    cellModel.viewToPresent = playbackView
+                } else {
+                    print("MoreOptionsSheet: PlaybackSpeedView could not be loaded from Nib")
+                }
+                // Only option that does not cause a crash
+                // cellModel.viewToPresent = PlaybackSpeedView()
             }
             models.append(cellModel)
         }


### PR DESCRIPTION
So currently, I'm trying to incorporate the `PlaybackSpeedView` into the `MediaMoreOptionsActionSheet` however, whenever I try to load the nib, in lines 87-92 there is a crash because of the not satisfying the  key-compliance of the audioDelayIndicator. This obviously doesn't happen when the PlaybackSpeedView is opened from the PlaybackSpeedView button in the `MovieViewController`. I have tried adding reconnecting the outlet for the audioDelayIndicator to no avail. 

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [ ] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [ ] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [ ] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
