### PR TITLE
CollectionModel: Iterate over files from the back to fix wrong deletion

### DIFF
--- a/Sources/EditController.swift
+++ b/Sources/EditController.swift
@@ -169,7 +169,7 @@ extension EditController: EditToolbarDelegate {
     func editToolbarDidDelete(_ editToolbar: EditToolbar) {
         var objectsToDelete = [VLCMLObject]()
 
-        for indexPath in selectedCellIndexPaths {
+        for indexPath in selectedCellIndexPaths.sorted(by: { $0 > $1 }) {
             objectsToDelete.append(model.anyfiles[indexPath.row])
         }
 


### PR DESCRIPTION
closes #604

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
