### PR TITLE
MediaCategorieViewController: Don't show empty view when we're searching

### DIFF
--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -195,6 +195,7 @@ class MediaCategoryViewController: UICollectionViewController, UICollectionViewD
     }
 
     func updateUIForContent() {
+        if isSearching { return }
         let isEmpty = isEmptyCollectionView()
         if isEmpty {
             collectionView?.setContentOffset(.zero, animated: false)


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
This fixes an issue where the searchbar was hidden when we had 0 search results and the oh you don't have files here view was shown