### PR TITLE
VLCMetadata: checkIsAudioOnly: Use numberOfVideoTracks

### DIFF
--- a/SharedSources/VLCMetadata.m
+++ b/SharedSources/VLCMetadata.m
@@ -90,20 +90,7 @@
 
 - (void)checkIsAudioOnly:(VLCMediaPlayer *)mediaPlayer
 {
-    if (!self.isAudioOnly) {
-        /* either what we are playing is not a file known to MLKit or
-         * MLKit fails to acknowledge that it is audio-only.
-         * Either way, do a more expensive check to see if it is really audio-only */
-        NSArray *tracks = mediaPlayer.media.tracksInformation;
-        NSUInteger trackCount = tracks.count;
-        self.isAudioOnly = YES;
-        for (NSUInteger x = 0 ; x < trackCount; x++) {
-            if ([[tracks[x] objectForKey:VLCMediaTracksInformationType] isEqualToString:VLCMediaTracksInformationTypeVideo]) {
-                self.isAudioOnly = NO;
-                break;
-            }
-        }
-    }
+    _isAudioOnly = mediaPlayer.numberOfVideoTracks == 0;
 }
 
 - (void)fillFromMetaDict:(VLCMediaPlayer *)mediaPlayer


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Fix `checkIsAudioOnly` by using `numberOfVideoTracks` from the mediaPlayer.

This fixes certain cases where the media was wrongly detected.

This only affects tvOS.
