### PR TITLE
VLCServerListViewController: localNetworkTableView: Fix cell sizing

### DIFF
--- a/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
@@ -96,6 +96,7 @@
     _localNetworkTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     _localNetworkTableView.rowHeight = [VLCNetworkListCell heightOfCell];
     _localNetworkTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    _localNetworkTableView.estimatedRowHeight = [VLCNetworkListCell heightOfCell];
 
     [self.navigationController.navigationBar setTranslucent:NO];
     self.navigationController.view.backgroundColor = PresentationTheme.current.colors.background;


### PR DESCRIPTION

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
By setting the estimatedRowHeight to 0, we disable estimated heights.
Indeed, it seems that the height was wrongly estimated by the system before.

(closes #627)
