### PR TITLE
VLCLocalNetworkServiceBrowserHTTP: Use same icon as wifi

### DIFF
--- a/SharedSources/ServerBrowsing/HTTP/VLCLocalNetworkServiceBrowserHTTP.m
+++ b/SharedSources/ServerBrowsing/HTTP/VLCLocalNetworkServiceBrowserHTTP.m
@@ -62,7 +62,7 @@
 @implementation VLCLocalNetworkServiceHTTP
 
 - (UIImage *)icon {
-    return [UIImage imageNamed:@"vlc-sharing"];
+    return [UIImage imageNamed:@"WifiIcon"];
 }
 
 - (id<VLCNetworkServerBrowser>)serverBrowser {


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Use wifi icon to represent other VLC-iOS instances over http service.
