### PR TITLE
VLCMovieViewController: Adapt movieView to notch for wide video

### DIFF
--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -367,17 +367,17 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
 
 - (void)setupConstraints
 {
-    NSArray *hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[panel]|"
-                                                                    options:0
-                                                                    metrics:nil
-                                                                      views:@{@"panel":_controllerPanel}];
+    NSArray *controlPanelHorizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[panel]|"
+                                                                                      options:0
+                                                                                      metrics:nil
+                                                                                        views:@{@"panel":_controllerPanel}];
 
-    NSArray *vConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:[panel]|"
+    NSArray *controlPanelVerticalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:[panel]|"
                                                                     options:0
                                                                     metrics:nil
                                                                       views:@{@"panel":_controllerPanel}];
-    [self.view addConstraints:hConstraints];
-    [self.view addConstraints:vConstraints];
+    [self.view addConstraints:controlPanelHorizontalConstraints];
+    [self.view addConstraints:controlPanelVerticalConstraints];
 
     //constraint within _trackSelectorContainer is setting it's height to the tableviews contentview
     NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:_trackSelectorContainer attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeWidth multiplier:2.0/3.0 constant:0];

--- a/Sources/VLCPlaybackService.h
+++ b/Sources/VLCPlaybackService.h
@@ -112,6 +112,8 @@ NS_SWIFT_NAME(PlaybackService)
 
 @property (nonatomic, nullable) VLCRendererItem *renderer;
 
+@property (nonatomic, readonly) VLCAspectRatio currentAspectRatio;
+
 + (VLCPlaybackService *)sharedInstance;
 - (VLCTime *)playedTime;
 #pragma mark - playback

--- a/Sources/VLCPlaybackService.m
+++ b/Sources/VLCPlaybackService.m
@@ -45,7 +45,6 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
     int _itemInMediaListToBePlayedFirst;
     NSTimer *_sleepTimer;
 
-    NSUInteger _currentAspectRatio;
     BOOL _isInFillToScreen;
     NSUInteger _previousAspectRatio;
     


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
In the case where we're playling a wide video(e.g. 21:9). This adapts the movieView's constraints to the notch.

 Closes #634