### PR TITLE
MediaCategoryViewController: Hide MiniPlayer on Edit

### DIFF
--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -161,6 +161,9 @@ class MediaCategoryViewController: UICollectionViewController, UICollectionViewD
             // Either didn't start or stopped before
             manager.start()
         }
+
+        PlaybackService.sharedInstance().setPlayerHidden(isEditing)
+
         manager.presentingViewController = self
         cachedCellSize = .zero
         collectionView.collectionViewLayout.invalidateLayout()
@@ -252,6 +255,9 @@ class MediaCategoryViewController: UICollectionViewController, UICollectionViewD
 
         editController.resetSelections()
         displayEditToolbar()
+
+        PlaybackService.sharedInstance().setPlayerHidden(editing)
+
         let layoutToBe = editing ? editCollectionViewLayout : UICollectionViewFlowLayout()
         collectionView?.setCollectionViewLayout(layoutToBe, animated: false, completion: {
             [unowned self] finished in

--- a/Sources/VLCPlaybackService.h
+++ b/Sources/VLCPlaybackService.h
@@ -34,6 +34,7 @@ extern NSString *const VLCPlaybackServicePlaybackPositionUpdated;
 @class VLCMetaData;
 @class VLCDialogProvider;
 @class VLCMLMedia;
+@class VLCPlayerDisplayController;
 
 @protocol VLCPlaybackServiceDelegate <NSObject>
 #if TARGET_OS_IOS
@@ -149,6 +150,8 @@ NS_SWIFT_NAME(PlaybackService)
 - (void)recoverPlaybackState;
 
 - (BOOL)isPlayingOnExternalScreen;
+
+- (void)setPlayerDisplayController:(VLCPlayerDisplayController *)playerDisplayController;
 
 - (void)setNeedsMetadataUpdate;
 - (void)scheduleSleepTimerWithInterval:(NSTimeInterval)timeInterval;

--- a/Sources/VLCPlaybackService.h
+++ b/Sources/VLCPlaybackService.h
@@ -151,6 +151,7 @@ NS_SWIFT_NAME(PlaybackService)
 
 - (BOOL)isPlayingOnExternalScreen;
 
+- (void)setPlayerHidden:(BOOL)hidden;
 - (void)setPlayerDisplayController:(VLCPlayerDisplayController *)playerDisplayController;
 
 - (void)setNeedsMetadataUpdate;

--- a/Sources/VLCPlaybackService.m
+++ b/Sources/VLCPlaybackService.m
@@ -1284,4 +1284,10 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
     _playerDisplayController = playerDisplayController;
 }
 
+- (void)setPlayerHidden:(BOOL)hidden
+{
+    [_playerDisplayController setEditing:hidden];
+    [_playerDisplayController dismissPlaybackView];
+}
+
 @end

--- a/Sources/VLCPlaybackService.m
+++ b/Sources/VLCPlaybackService.m
@@ -21,6 +21,8 @@
 #import <AVFoundation/AVFoundation.h>
 #import "VLCRemoteControlService.h"
 #import "VLCMetadata.h"
+#import "VLCPlayerDisplayController.h"
+
 #if TARGET_OS_IOS
 #import "VLC-Swift.h"
 #endif
@@ -62,6 +64,8 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
 
     NSMutableArray *_shuffleStack;
     void (^_playbackCompletion)(BOOL success);
+
+    VLCPlayerDisplayController *_playerDisplayController;
 }
 
 @end
@@ -1271,4 +1275,13 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
     _renderer = renderer;
     [_mediaPlayer setRendererItem:_renderer];
 }
+
+
+#pragma mark - PlayerDisplayController
+
+- (void)setPlayerDisplayController:(VLCPlayerDisplayController *)playerDisplayController
+{
+    _playerDisplayController = playerDisplayController;
+}
+
 @end

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -66,6 +66,8 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
 {
     self.view = [[VLCUntouchableView alloc] initWithFrame:self.view.frame];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+
+    [[VLCPlaybackService sharedInstance] setPlayerDisplayController:self];
 }
 
 #pragma mark - properties


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
For now, this hide the mini player when entering edit mode.
This uses a behaviour already in place inside `VLCPlayerDisplayController`. 

Therefore, this doesn't change from the old behaviour.

This might not be ideal, even could be considered as a workaround, but I believe this is compromise we could agree on for the 3.2.0 release.

Closes #626