### PR TITLE
VLCMovieViewController: Perform layout related method on main thread

### DIFF
--- a/Sources/VLCMovieViewController.m
+++ b/Sources/VLCMovieViewController.m
@@ -645,7 +645,7 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
 
     if (!_playbackWillClose) {
         _displayRemainingTime = [[defaults objectForKey:kVLCShowRemainingTime] boolValue];
-        [self updateTimeDisplayButton];
+        [self performSelectorOnMainThread:@selector(updateTimeDisplayButton) withObject:nil waitUntilDone:NO];
     }
 
     _volumeGestureEnabled = [[defaults objectForKey:kVLCSettingVolumeGesture] boolValue];


### PR DESCRIPTION

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Run `updateTimeDisplayButton` on the main thread when called by `UpdateDefaults`.
