### PR TITLE
VLCSettingsTableViewCell: Fix selected backgroundColor on theme change

### DIFF
--- a/Sources/VLCSettingsTableViewCell.swift
+++ b/Sources/VLCSettingsTableViewCell.swift
@@ -16,6 +16,7 @@ class VLCSettingsTableViewCell: UITableViewCell {
     
     @objc fileprivate func themeDidChange() {
         backgroundColor = PresentationTheme.current.colors.background
+        selectedBackgroundView?.backgroundColor = PresentationTheme.current.colors.mediaCategorySeparatorColor
         textLabel?.textColor = PresentationTheme.current.colors.cellTextColor
         detailTextLabel?.textColor = PresentationTheme.current.colors.cellDetailTextColor
     }


### PR DESCRIPTION
Selected background color is not the good one after switching
theme color leading to white light cells in dark mode and vice versa.

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
VLCSettingsTableViewCell: Fix selected backgroundColor on theme change