### PR TITLE
ActionSheet: Fix first and last cell background colors on theme change

### DIFF
--- a/Sources/ActionSheet/ActionSheet.swift
+++ b/Sources/ActionSheet/ActionSheet.swift
@@ -200,12 +200,6 @@ class ActionSheet: UIViewController {
         collectionView.backgroundColor = PresentationTheme.current.colors.background
         headerView.backgroundColor = PresentationTheme.current.colors.background
         headerView.title.textColor = PresentationTheme.current.colors.cellTextColor
-        for cell in collectionView.visibleCells {
-            if let cell = cell as? ActionSheetCell {
-                cell.backgroundColor = PresentationTheme.current.colors.background
-                cell.name.textColor = PresentationTheme.current.colors.cellTextColor
-            }
-        }
         collectionView.layoutIfNeeded()
     }
     

--- a/Sources/ActionSheet/ActionSheetCell.swift
+++ b/Sources/ActionSheet/ActionSheetCell.swift
@@ -219,7 +219,9 @@ class ActionSheetCell: UICollectionViewCell {
     }
 
     private func setupViews() {
-        backgroundColor = PresentationTheme.current.colors.background
+        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme),
+                                               name: .VLCThemeDidChangeNotification, object: nil)
+        updateTheme()
 
         stackView.addArrangedSubview(icon)
         stackView.addArrangedSubview(name)
@@ -242,5 +244,10 @@ class ActionSheetCell: UICollectionViewCell {
             stackView.heightAnchor.constraint(equalTo: heightAnchor),
             stackView.topAnchor.constraint(equalTo: topAnchor)
         ])
+    }
+
+    @objc private func updateTheme() {
+        backgroundColor = PresentationTheme.current.colors.background
+        name.textColor = PresentationTheme.current.colors.cellTextColor
     }
 }


### PR DESCRIPTION
The background color could stay the same after switching dark/light themes.
This has been fixed by adding a updateTheme notification / method
in ActionSheetCell and removing cell specific code from ActionSheet's
updateTheme method.

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Add a updateTheme notification / method in ActionSheetCell and
remove cell specific code from ActionSheet's updateTheme method.