### PR TITLE
VLCSettingsController: Fix biometrics settings

### DIFF
--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -163,6 +163,7 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
 {
     [self updateForPasscode:nil];
     [self.settingsStore setBool:false forKey:kVLCSettingPasscodeOnKey];
+    [self filterCellsWithAnimation:NO];
 }
 
 - (void)PAPasscodeViewControllerDidSetPasscode:(PAPasscodeViewController *)controller


### PR DESCRIPTION
Update biometric settings activation on cancelling passcode activation.

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
Update biometric settings activation on cancelling passcode activation.
Touch ID settings no longer show up after cancelling passcode activation.