### PR TITLE
Settings: Add bright/dark/auto theme selector, remove dark mode switch

### DIFF
--- a/Resources/Settings.bundle/Root.inApp.plist
+++ b/Resources/Settings.bundle/Root.inApp.plist
@@ -20,15 +20,25 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string>NO</string>
+			<integer>0</integer>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
 			<key>Key</key>
 			<string>darkMode</string>
 			<key>Title</key>
 			<string>SETTINGS_DARKTHEME</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>IASKSubtitle</key>
-			<string>SETTINGS_THEME_SUBTITLE</string>
+			<key>Titles</key>
+			<array>
+				<string>SETTINGS_THEME_BRIGHT</string>
+				<string>SETTINGS_THEME_DARK</string>
+				<string>SETTINGS_THEME_SYSTEM</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/Resources/Settings.bundle/de.lproj/Root.strings
+++ b/Resources/Settings.bundle/de.lproj/Root.strings
@@ -4,11 +4,13 @@
 "SETTINGS_VIDEO_TITLE" = "Video";
 "SETTINGS_AUDIO_TITLE" = "Audio";
 
-"SETTINGS_THEME_SUBTITLE" = "App-Farben ändern";
+"SETTINGS_THEME_BRIGHT" = "Helles Design";
+"SETTINGS_THEME_DARK" = "Dunkles Design";
+"SETTINGS_THEME_SYSTEM" = "Automatisch";
 "SETTINGS_PRIVACY_SUBTITLE" = "In den Einstellungen öffnen";
 "SETTINGS_PASSCODE_LOCK_SUBTITLE" = "Zugriff auf Ihre Inhalte sichern";
 
-"SETTINGS_DARKTHEME" = "Dunkles Design";
+"SETTINGS_DARKTHEME" = "Aussehen";
 "SETTINGS_TIME_STRETCH_AUDIO" = "Audio-Tonzeitstreckung";
 "SETTINGS_BACKGROUND_AUDIO" = "Hintergrundaudiowiedergabe";
 "SETTINGS_GENERIC_TITLE" = "Allgemein";

--- a/Resources/Settings.bundle/en-GB.lproj/Root.strings
+++ b/Resources/Settings.bundle/en-GB.lproj/Root.strings
@@ -4,11 +4,13 @@
 "SETTINGS_VIDEO_TITLE" = "Video";
 "SETTINGS_AUDIO_TITLE" = "Audio";
 
-"SETTINGS_THEME_SUBTITLE" = "Change app colours";
+"SETTINGS_THEME_BRIGHT" = "Bright theme";
+"SETTINGS_THEME_DARK" = "Dark theme";
+"SETTINGS_THEME_SYSTEM" = "Automatic";
 "SETTINGS_PRIVACY_SUBTITLE" = "Open in Settings";
 "SETTINGS_PASSCODE_LOCK_SUBTITLE" = "Secure access to your content";
 
-"SETTINGS_DARKTHEME" = "Dark Theme";
+"SETTINGS_DARKTHEME" = "Appearance";
 "SETTINGS_TIME_STRETCH_AUDIO" = "Time-stretching audio";
 "SETTINGS_BACKGROUND_AUDIO" = "Audio playback in background";
 "SETTINGS_GENERIC_TITLE" = "Generic";

--- a/Resources/Settings.bundle/en.lproj/Root.strings
+++ b/Resources/Settings.bundle/en.lproj/Root.strings
@@ -4,11 +4,13 @@
 "SETTINGS_VIDEO_TITLE" = "Video";
 "SETTINGS_AUDIO_TITLE" = "Audio";
 
-"SETTINGS_THEME_SUBTITLE" = "Change app colors";
+"SETTINGS_THEME_BRIGHT" = "Bright theme";
+"SETTINGS_THEME_DARK" = "Dark theme";
+"SETTINGS_THEME_SYSTEM" = "Automatic";
 "SETTINGS_PRIVACY_SUBTITLE" = "Open in Settings";
 "SETTINGS_PASSCODE_LOCK_SUBTITLE" = "Secure access to your content";
 
-"SETTINGS_DARKTHEME" = "Dark Theme";
+"SETTINGS_DARKTHEME" = "Appearance";
 "SETTINGS_TIME_STRETCH_AUDIO" = "Time-stretching audio";
 "SETTINGS_BACKGROUND_AUDIO" = "Audio playback in background";
 "SETTINGS_GENERIC_TITLE" = "Generic";

--- a/Resources/Settings.bundle/fr.lproj/Root.strings
+++ b/Resources/Settings.bundle/fr.lproj/Root.strings
@@ -4,11 +4,13 @@
 "SETTINGS_VIDEO_TITLE" = "Vidéo";
 "SETTINGS_AUDIO_TITLE" = "Audio";
 
-"SETTINGS_THEME_SUBTITLE" = "Changer les couleurs de l'application";
+"SETTINGS_THEME_BRIGHT" = "Thème claire";
+"SETTINGS_THEME_DARK" = "Thème sombre";
+"SETTINGS_THEME_SYSTEM" = "Automatique";
 "SETTINGS_PRIVACY_SUBTITLE" = "Ouvrir dans les paramètres";
 "SETTINGS_PASSCODE_LOCK_SUBTITLE" = "Accès sécurisé à votre contenu";
 
-"SETTINGS_DARKTHEME" = "Thème sombre";
+"SETTINGS_DARKTHEME" = "Apparence";
 "SETTINGS_TIME_STRETCH_AUDIO" = "Étirement temporel audio";
 "SETTINGS_BACKGROUND_AUDIO" = "Lecture audio en arrière-plan";
 "SETTINGS_GENERIC_TITLE" = "Générique";

--- a/SharedSources/PresentationTheme.swift
+++ b/SharedSources/PresentationTheme.swift
@@ -88,8 +88,11 @@ extension Notification.Name {
     static let darkTheme = PresentationTheme(colors: darkPalette)
 
     static var current: PresentationTheme = {
-        let isDarkTheme = UserDefaults.standard.bool(forKey: kVLCSettingAppTheme)
-        return isDarkTheme ? PresentationTheme.darkTheme : PresentationTheme.brightTheme
+        if let appTheme = UserDefaults.standard.value(forKey: kVLCSettingAppTheme) {
+            return appTheme as! Int32 == kVLCSettingAppThemeDark ? PresentationTheme.darkTheme : PresentationTheme.brightTheme
+        } else {
+            return PresentationTheme.brightTheme
+        }
     }() {
         didSet {
             AppearanceManager.setupAppearance(theme: self.current)
@@ -100,6 +103,22 @@ extension Notification.Name {
     init(colors: ColorPalette) {
         self.colors = colors
         super.init()
+    }
+
+    static func settingsDidUpdate() {
+        if let themeSettings = UserDefaults.standard.value(forKey: kVLCSettingAppTheme) {
+            let mode = themeSettings as! Int32
+            if mode == kVLCSettingAppThemeBright {
+                PresentationTheme.current = PresentationTheme.brightTheme
+            } else if mode == kVLCSettingAppThemeDark {
+                PresentationTheme.current = PresentationTheme.darkTheme
+            } else {
+                if #available(iOS 13.0, *) {
+                    let isSystemDarkTheme = UIScreen.main.traitCollection.userInterfaceStyle == .dark
+                    PresentationTheme.current = isSystemDarkTheme ? PresentationTheme.darkTheme : PresentationTheme.brightTheme
+                }
+            }
+        }
     }
 
     let colors: ColorPalette

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -55,7 +55,8 @@
 {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
-    NSDictionary *appDefaults = @{kVLCSettingPasscodeAllowFaceID : @(1),
+    NSDictionary *appDefaults = @{kVLCSettingAppTheme : @(kVLCSettingAppThemeBright),
+                                  kVLCSettingPasscodeAllowFaceID : @(1),
                                   kVLCSettingPasscodeAllowTouchID : @(1),
                                   kVLCSettingContinueAudioInBackgroundKey : @(YES),
                                   kVLCSettingStretchAudio : @(NO),

--- a/Sources/VLCConstants.h
+++ b/Sources/VLCConstants.h
@@ -18,6 +18,9 @@
 #define kVLCSettingPasscodeAllowFaceID @"AllowFaceID"
 #define kVLCThemeDidChangeNotification @"themeDidChangeNotfication"
 #define kVLCSettingAppTheme @"darkMode"
+#define kVLCSettingAppThemeBright 0
+#define kVLCSettingAppThemeDark 1
+#define kVLCSettingAppThemeSystem 2
 #define kVLCOptimizeItemNamesForDisplay @"MLDecrapifyTitles"
 #define kVLCSettingAbout @"about"
 #define kVLCAutomaticallyPlayNextItem @"AutomaticallyPlayNextItem"

--- a/Sources/VLCSettingsController.m
+++ b/Sources/VLCSettingsController.m
@@ -144,10 +144,6 @@ NSString * const kVLCSectionTableHeaderViewIdentifier = @"VLCSectionTableHeaderV
             [self.navigationController presentViewController:navigationController animated:YES completion:nil];
         }
     }
-    if ([notification.object isEqual:kVLCSettingAppTheme]) {
-        BOOL darkTheme = [[notification.userInfo objectForKey:kVLCSettingAppTheme] boolValue];
-        PresentationTheme.current = darkTheme ? PresentationTheme.darkTheme : PresentationTheme.brightTheme;
-    }
 }
 
 - (void)showAbout

--- a/Sources/VLCSettingsSpecifierManager.swift
+++ b/Sources/VLCSettingsSpecifierManager.swift
@@ -23,6 +23,13 @@ class VLCSettingsSpecifierManager: NSObject {
             assertionFailure("VLCSettingsSpecifierManager: No rows provided for \(specifier?.key() ?? "null specifier")")
             return []
         }
+        if specifier?.key() == kVLCSettingAppTheme {
+            if #available(iOS 13.0, *) {
+                return items
+            } else {
+                return items.subarray(with: NSRange(location: 0, length: items.count - 1)) as NSArray
+            }
+        }
         return items
     }
     
@@ -60,6 +67,9 @@ extension VLCSettingsSpecifierManager: ActionSheetDelegate {
     func actionSheet(collectionView: UICollectionView, didSelectItem item: Any, At indexPath: IndexPath) {
         settingsStore.setObject(item, forKey: specifier?.key())
         settingsStore.synchronize()
+        if specifier?.key() == kVLCSettingAppTheme {
+            PresentationTheme.settingsDidUpdate()
+        }
     }
 }
 

--- a/Sources/VLCTabBarCoordinator.swift
+++ b/Sources/VLCTabBarCoordinator.swift
@@ -100,10 +100,13 @@ extension UITabBarController {
                 // there was a userInterfaceStyle change.
                 return
             }
+            guard let themeSettings = UserDefaults.standard.value(forKey: kVLCSettingAppTheme),
+                      themeSettings as! Int32 == kVLCSettingAppThemeSystem else {
+                // Check for theme settings not being following system theme
+                return
+            }
 
             let isSystemDarkTheme = traitCollection.userInterfaceStyle == .dark
-
-            UserDefaults.standard.set(isSystemDarkTheme, forKey: kVLCSettingAppTheme)
             PresentationTheme.current = isSystemDarkTheme ? PresentationTheme.darkTheme : PresentationTheme.brightTheme
         }
     }


### PR DESCRIPTION
In VLC settings, remove the old switch that allowed to enable dark mode.
Add a new selector with Bright, Dark and Automatic options which :
 - forces bright theme
 - forces dark theme
 - follows system settings

Changing iOS 13 system-wide theme will not change VLC settings anymore.

Also add en, en_uk, fr and de translations for the new switches.

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
In VLC settings, remove the old switch that allowed to enable dark mode.
Add a new selector with Bright, Dark and Automatic options which :
 - forces bright theme
 - forces dark theme
 - follows system settings

Changing iOS 13 system-wide theme will not change VLC settings anymore.

Also add the following translations for the new switches :
 - English
 - English (United Kingdom)
 - French
 - German
