### PR TITLE
MediaCategoryViewController: Fix safearea for pre-loaded viewControllers

### DIFF
--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -148,6 +148,16 @@ class MediaCategoryViewController: UICollectionViewController, UICollectionViewD
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        if #available(iOS 11.0, *) {
+            if let applicationSharedWindow = UIApplication.shared.keyWindow {
+                // Sets additional safe area insets as
+                //  - view controller's view doesn't know about safe area until it's shown
+                //  - viewSafeAreaInsetsDidChange is not called on tab switch
+                // These additional safe area insets are to be set to .zero on viewSafeAreaInsetsDidChange
+                // since the view will have the true safe area insets at this point.
+                additionalSafeAreaInsets = applicationSharedWindow.safeAreaInsets
+            }
+        }
         setupCollectionView()
         setupSearchBar()
         setupEditToolbar()
@@ -393,6 +403,13 @@ extension MediaCategoryViewController {
     }
 
     override func viewSafeAreaInsetsDidChange() {
+        if #available(iOS 11.0, *) {
+            // At this point, we have valid safe area insets for the view
+            // therefore we do not need any additional insets anymore.
+            if additionalSafeAreaInsets != .zero {
+                additionalSafeAreaInsets = .zero
+            }
+        }
         cachedCellSize = .zero
         collectionView?.collectionViewLayout.invalidateLayout()
     }


### PR DESCRIPTION
Set additionalSafeAreaInsets for the viewController so even views that
have no parent views get valid safeAreaInsets.
Update viewSafeAreaInsetsDidChange to remove additionalSafeAreaInsets
when the view gets valid safeAreaInsets.

Closes #506

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
