### PR TITLE
AppCoordinator: Fix round corners

### DIFF
--- a/Sources/Coordinators/AppCoordinator.swift
+++ b/Sources/Coordinators/AppCoordinator.swift
@@ -49,6 +49,15 @@ class Services: NSObject {
                                                            right: 0)
         playerDisplayController.realBottomAnchor = tabBarController.tabBar.topAnchor
         playerDisplayController.didMove(toParent: tabBarController)
+
+        // Set app cornerRadius back to 0
+        // For some unknown reason, reading tabBarController anchors sets round corners for the entire app.
+        // We set cornerRadius to 0 for the topmost layer so there are no round corners anymore.
+        if #available(iOS 13, *) {
+            if let applicationSharedWindow = UIApplication.shared.keyWindow {
+                applicationSharedWindow.rootViewController?.view.layer.superlayer?.cornerRadius = 0
+            }
+        }
     }
 
     @objc func start() {


### PR DESCRIPTION
For some unknown reason, reading tabBarController anchors
sets round corners for the entire app.
A workaround is to set cornerRadius to 0 for the topmost layer
so there are no round corners anymore.

Closes #662

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
