### PR TITLE
Adding snap-to-speed with haptic feedback when changing playback speed

### DIFF
--- a/Sources/PlaybackSpeedView.swift
+++ b/Sources/PlaybackSpeedView.swift
@@ -104,9 +104,29 @@ class PlaybackSpeedView: VLCFrostedGlasView {
 
     @IBAction func playbackSliderAction(sender: UISlider) {
         if sender == playbackSpeedSlider {
-            let speed = exp2(sender.value)
-            vpc.playbackRate = speed
-            playbackSpeedIndicator.text = String(format: "%.2fx", speed)
+            let values: [Float] = [0.25, 0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0]
+            let rawSpeed = exp2(sender.value)
+            
+            var snappedSpeed: Float = 1.0
+            var closestSpeedDiff: Float = Float.greatestFiniteMagnitude
+            for value in values {
+                let diff = abs(value - rawSpeed)
+                if diff < closestSpeedDiff {
+                    snappedSpeed = value
+                    closestSpeedDiff = diff
+                }
+            }
+            
+            playbackSpeedSlider.value = log2(snappedSpeed)
+            playbackSpeedIndicator.text = String(format: "%.2fx", snappedSpeed)
+            
+            if snappedSpeed != vpc.playbackRate {
+                vpc.playbackRate = snappedSpeed
+                if #available(iOS 10.0, *) {
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
+                }
+            }
         } else if sender == audioDelaySlider {
             let delay = round(sender.value / 50) * 50
             vpc.audioDelay = delay


### PR DESCRIPTION
- Adding snap-to-speed with haptic feedback when changing playback speed
- I also added a set of a convenient predefined set of speeds to snap to: 0.25, 0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [ ] I've updated the documentation if necessary.

### Description
Changing the playback speed has been so difficult on the screen that I often went back to my Apple Watch to set it to 2x playback. This was due to the totally free-floating setting with double-digit precision (it is not realistic that anyone would want to set the playback speed to 1.07x)

Modelling other playback tools, I set the slider to snap to one of the predefined settings with haptic feedback, so users can be much more confident to set the playback speed they prefer.

Tested in both simulator and a physical device.