### PR TITLE
SMB: Enable share path

### DIFF
--- a/SharedSources/ServerBrowsing/SMB/VLCLocalNetworkServiceBrowserDSM.m
+++ b/SharedSources/ServerBrowsing/SMB/VLCLocalNetworkServiceBrowserDSM.m
@@ -88,7 +88,8 @@ static NSString *const VLCLocalNetworkServiceDSMWorkgroupIdentifier = @"VLCLocal
 {
     NSURLComponents *components = [[NSURLComponents alloc] init];
     components.scheme = @"smb";
-    components.host = login.address;
+    components.host = [login.address componentsSeparatedByString:@"/"] [0];
+    components.path = [NSString stringWithFormat:@"/%@", [login.address componentsSeparatedByString:@"/"] [1]];
     components.port = login.port;
     NSURL *url = components.URL;
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
Correctly parses address into host and path.

Existing:
Address: /Share/PathName
Host: Share%2fPathName
Path: null
URL: Share%2fPathName
Result: FAIL

Update:
Address: /Share/PathName
Host: Share
Path: /PathName
URL: /Share/PathName
Result: PASS

(closes #22938)
