### PR TITLE
Localization: fix incorrect SETTINGS_THEME_BRIGHT translation

### DIFF
--- a/Resources/Settings.bundle/ru.lproj/Root.strings
+++ b/Resources/Settings.bundle/ru.lproj/Root.strings
@@ -4,7 +4,7 @@
 "SETTINGS_VIDEO_TITLE" = "Видео";
 "SETTINGS_AUDIO_TITLE" = "Звук";
 
-"SETTINGS_THEME_BRIGHT" = "Темная тема";
+"SETTINGS_THEME_BRIGHT" = "Светлая тема";
 "SETTINGS_THEME_DARK" = "Тёмная тема";
 "SETTINGS_THEME_SYSTEM" = "Автоматически";
 "SETTINGS_PRIVACY_SUBTITLE" = "Открыть настройки";


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
Localization: fix incorrect SETTINGS_THEME_BRIGHT translation
