### PR TITLE
#913 : dark and light mode improper switch fix

### DIFF
--- a/SharedSources/VLCPlaybackInfoSubtitlesFetcherViewController.m
+++ b/SharedSources/VLCPlaybackInfoSubtitlesFetcherViewController.m
@@ -142,6 +142,7 @@
     [self.navigationItem.titleView setTintColor:colors.navigationbarTextColor];
     self.view.backgroundColor = self.tableView.backgroundColor = colors.background;
     [self.tableView reloadData];
+    [self setNeedsStatusBarAppearanceUpdate];
 #endif
 }
 

--- a/Sources/ActionSheet/ActionSheet.swift
+++ b/Sources/ActionSheet/ActionSheet.swift
@@ -80,12 +80,12 @@ class ActionSheet: UIViewController {
     }()
 
     private lazy var mainStackView: UIStackView = {
-        let mainStackView = UIStackView()
-        mainStackView.spacing = 0
-        mainStackView.axis = .vertical
-        mainStackView.alignment = .center
-        mainStackView.translatesAutoresizingMaskIntoConstraints = false
-        return mainStackView
+        let stackView = UIStackView()
+        stackView.spacing = 0
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private lazy var maxCollectionViewHeightConstraint: NSLayoutConstraint = {

--- a/Sources/ActionSheet/ActionSheetSortSectionHeader.swift
+++ b/Sources/ActionSheet/ActionSheetSortSectionHeader.swift
@@ -30,66 +30,66 @@ class ActionSheetSortSectionHeader: ActionSheetSectionHeader {
     private let userDefaults = UserDefaults.standard
 
     private let descendingStackView: UIStackView = {
-        let descendingStackView = UIStackView()
-        descendingStackView.spacing = 0
-        descendingStackView.alignment = .center
-        descendingStackView.translatesAutoresizingMaskIntoConstraints = false
-        return descendingStackView
+        let stackView = UIStackView()
+        stackView.spacing = 0
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private let gridLayoutStackView: UIStackView = {
-        let descendingStackView = UIStackView()
-        descendingStackView.spacing = 0
-        descendingStackView.alignment = .center
-        descendingStackView.translatesAutoresizingMaskIntoConstraints = false
-        return descendingStackView
+        let stackView = UIStackView()
+        stackView.spacing = 0
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private let mainStackView: UIStackView = {
-        let descendingStackView = UIStackView()
-        descendingStackView.spacing = 10
-        descendingStackView.axis = .vertical
-        descendingStackView.translatesAutoresizingMaskIntoConstraints = false
-        return descendingStackView
+        let stackView = UIStackView()
+        stackView.spacing = 10
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private let descendingLabel: UILabel = {
-        let descendingLabel = UILabel()
-        descendingLabel.textColor = PresentationTheme.current.colors.cellTextColor
-        descendingLabel.text = NSLocalizedString("DESCENDING_LABEL", comment: "")
-        descendingLabel.font = UIFont.systemFont(ofSize: 15, weight: .medium)
-        descendingLabel.translatesAutoresizingMaskIntoConstraints = false
-        return descendingLabel
+        let label = UILabel()
+        label.textColor = PresentationTheme.current.colors.cellTextColor
+        label.text = NSLocalizedString("DESCENDING_LABEL", comment: "")
+        label.font = UIFont.systemFont(ofSize: 15, weight: .medium)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     let actionSwitch: UISwitch = {
-        let actionSwitch = UISwitch()
-        actionSwitch.addTarget(self, action: #selector(handleDescendingSwitch(_:)), for: .valueChanged)
-        actionSwitch.accessibilityLabel = NSLocalizedString("DESCENDING_SWITCH_LABEL", comment: "")
-        actionSwitch.accessibilityHint = NSLocalizedString("DESCENDING_SWITCH_HINT", comment: "")
-        actionSwitch.translatesAutoresizingMaskIntoConstraints = false
-        return actionSwitch
+        let aSwitch = UISwitch()
+        aSwitch.addTarget(self, action: #selector(handleDescendingSwitch(_:)), for: .valueChanged)
+        aSwitch.accessibilityLabel = NSLocalizedString("DESCENDING_SWITCH_LABEL", comment: "")
+        aSwitch.accessibilityHint = NSLocalizedString("DESCENDING_SWITCH_HINT", comment: "")
+        aSwitch.translatesAutoresizingMaskIntoConstraints = false
+        return aSwitch
     }()
 
     private let gridLayoutLabel: UILabel = {
-        let descendingLabel = UILabel()
-        descendingLabel.text = NSLocalizedString("GRID_LAYOUT", comment: "")
-        descendingLabel.accessibilityLabel = NSLocalizedString("GRID_LAYOUT", comment: "")
-        descendingLabel.accessibilityHint = NSLocalizedString("GRID_LAYOUT", comment: "")
+        let label = UILabel()
+        label.text = NSLocalizedString("GRID_LAYOUT", comment: "")
+        label.accessibilityLabel = NSLocalizedString("GRID_LAYOUT", comment: "")
+        label.accessibilityHint = NSLocalizedString("GRID_LAYOUT", comment: "")
         //TODO: Set appropriate accessibilityLabel and accessibilityHint
-        descendingLabel.font = .systemFont(ofSize: 15, weight: .medium)
-        descendingLabel.textColor = PresentationTheme.current.colors.cellTextColor
-        descendingLabel.translatesAutoresizingMaskIntoConstraints = false
-        return descendingLabel
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.textColor = PresentationTheme.current.colors.cellTextColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     let layoutChangeSwitch: UISwitch = {
-        let actionSwitch = UISwitch()
-        actionSwitch.addTarget(self,
+        let aSwitch = UISwitch()
+        aSwitch.addTarget(self,
                                action: #selector(handleLayoutChangeSwitch(_:)),
                                for: .valueChanged)
-        actionSwitch.translatesAutoresizingMaskIntoConstraints = false
-        return actionSwitch
+        aSwitch.translatesAutoresizingMaskIntoConstraints = false
+        return aSwitch
     }()
 
     weak var delegate: ActionSheetSortSectionHeaderDelegate?
@@ -123,6 +123,7 @@ class ActionSheetSortSectionHeader: ActionSheetSectionHeader {
     @objc private func updateTheme() {
         backgroundColor = PresentationTheme.current.colors.background
         descendingLabel.textColor = PresentationTheme.current.colors.cellTextColor
+        gridLayoutLabel.textColor = PresentationTheme.current.colors.cellTextColor
     }
 
     @objc func handleDescendingSwitch(_ sender: UISwitch) {

--- a/Sources/AppearanceManager.swift
+++ b/Sources/AppearanceManager.swift
@@ -57,7 +57,7 @@ class AppearanceManager: NSObject {
             UITabBar.appearance().unselectedItemTintColor = theme.colors.cellDetailTextColor
         }
 
-        UIPageControl.appearance().backgroundColor = theme.colors.background
+        UIPageControl.appearance().backgroundColor = .clear
         UIPageControl.appearance().pageIndicatorTintColor = .lightGray
         UIPageControl.appearance().currentPageIndicatorTintColor = theme.colors.orangeUI
     }

--- a/Sources/AppearanceManager.swift
+++ b/Sources/AppearanceManager.swift
@@ -81,4 +81,23 @@ extension UINavigationController {
     override open var childForStatusBarStyle: UIViewController? {
         return self.topViewController
     }
+
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .VLCThemeDidChangeNotification, object: nil)
+        updateTheme()
+    }
+
+    @objc func updateTheme() {
+        if #available(iOS 11.0, *) {
+            navigationBar.largeTitleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: PresentationTheme.current.colors.navigationbarTextColor
+            ]
+        }
+        if #available(iOS 13.0, *) {
+            let navigationBarAppearance = AppearanceManager.navigationbarAppearance()
+            navigationBar.standardAppearance = navigationBarAppearance
+            navigationBar.scrollEdgeAppearance = navigationBarAppearance
+        }
+    }
 }

--- a/Sources/EditToolbar.swift
+++ b/Sources/EditToolbar.swift
@@ -32,9 +32,9 @@ class EditToolbar: UIView {
     }()
 
     private var rightStackView: UIStackView = {
-        let rightStackView = UIStackView()
-        rightStackView.translatesAutoresizingMaskIntoConstraints = false
-        return rightStackView
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private var addToPlaylistButton: UIButton = {

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginViewController.m
@@ -71,11 +71,6 @@
                                               initWithTitle:NSLocalizedString(@"BUTTON_CONNECT", nil)
                                               style:UIBarButtonItemStyleDone target:self
                                               action:@selector(connectLoginDataSource)];
-    if (@available(iOS 13.0, *)) {
-        UINavigationBarAppearance *navigationBarAppearance = [VLCAppearanceManager navigationbarAppearance];
-        self.navigationController.navigationBar.standardAppearance = navigationBarAppearance;
-        self.navigationController.navigationBar.scrollEdgeAppearance = navigationBarAppearance;
-    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle
@@ -166,6 +161,7 @@
     self.view.backgroundColor = PresentationTheme.current.colors.background;
     self.tableView.backgroundColor = PresentationTheme.current.colors.background;
     self.tableView.separatorColor = PresentationTheme.current.colors.background;
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 #pragma mark - VLCNetworkLoginDataSourceProtocolDelegate

--- a/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCServerListViewController.m
@@ -401,11 +401,6 @@
     _localNetworkTableView.separatorColor = PresentationTheme.current.colors.background;
     _refreshControl.backgroundColor = PresentationTheme.current.colors.background;
     self.navigationController.view.backgroundColor = PresentationTheme.current.colors.background;
-    if (@available(iOS 13.0, *)) {
-        UINavigationBarAppearance *navigationBarAppearance = [VLCAppearanceManager navigationbarAppearance];
-        self.navigationController.navigationBar.standardAppearance = navigationBarAppearance;
-        self.navigationController.navigationBar.scrollEdgeAppearance = navigationBarAppearance;
-    }
     [self setNeedsStatusBarAppearanceUpdate];
 }
 

--- a/Sources/MediaCategories/MediaCategoryViewController.swift
+++ b/Sources/MediaCategories/MediaCategoryViewController.swift
@@ -291,11 +291,6 @@ class MediaCategoryViewController: UICollectionViewController, UISearchBarDelega
     @objc func themeDidChange() {
         collectionView?.backgroundColor = PresentationTheme.current.colors.background
         searchBar.backgroundColor = PresentationTheme.current.colors.background
-
-        if #available(iOS 13.0, *) {
-            navigationController?.navigationBar.standardAppearance = AppearanceManager.navigationbarAppearance()
-            navigationController?.navigationBar.scrollEdgeAppearance = AppearanceManager.navigationbarAppearance()
-        }
         setNeedsStatusBarAppearanceUpdate()
     }
 

--- a/Sources/Playback/VLCMovieViewController.m
+++ b/Sources/Playback/VLCMovieViewController.m
@@ -1980,7 +1980,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
 {
     BOOL orientationIslocked = _interfaceIsLocked || [_vpc currentMediaIs360Video];
     UIInterfaceOrientationMask maskFromOrientation = 1 << _lockedOrientation;
-    return orientationIslocked ? maskFromOrientation :  UIInterfaceOrientationMaskAll;
+    return orientationIslocked ? maskFromOrientation : UIInterfaceOrientationMaskAll;
 }
 
 - (BOOL)shouldAutorotate

--- a/Sources/Settings/Controller/AboutController.swift
+++ b/Sources/Settings/Controller/AboutController.swift
@@ -72,7 +72,6 @@ class AboutController: UIViewController {
 
     private func setupNavigationBar() {
         self.navigationItem.titleView = UIImageView(image: UIImage(named: "AboutTitle"))
-        self.navigationItem.titleView?.tintColor = PresentationTheme.current.colors.navigationbarTextColor
         self.navigationController?.navigationBar.isOpaque = true
         setupBarButtons()
     }

--- a/Sources/Settings/Controller/PasscodeLockController.swift
+++ b/Sources/Settings/Controller/PasscodeLockController.swift
@@ -156,20 +156,15 @@ class PasscodeLockController: UIViewController {
                                     for: .editingChanged)
     }
 
-    private func setNavBarAppearance() {
-        if #available(iOS 13.0, *) {
-            let navigationBarAppearance = AppearanceManager.navigationbarAppearance
-            self.navigationController?.navigationBar.standardAppearance = navigationBarAppearance()
-            self.navigationController?.navigationBar.scrollEdgeAppearance = navigationBarAppearance()
-        }
-    }
-
 // MARK: - Observer & Bar Button Actions
     @objc private func setupTheme() {
         view.backgroundColor = PresentationTheme.current.colors.background
         messageLabel.textColor = PresentationTheme.current.colors.cellTextColor
         passcodeTextField.textColor = PresentationTheme.current.colors.cellTextColor
-        setNavBarAppearance()
+        if action == .set {
+            setupBarButton()
+        }
+        setNeedsStatusBarAppearanceUpdate()
     }
 
     @objc private func dismissView() {

--- a/Sources/Settings/Controller/SettingsController.swift
+++ b/Sources/Settings/Controller/SettingsController.swift
@@ -47,24 +47,22 @@ class SettingsController: UITableViewController {
 
     private func setup() {
         setupUI()
-        setNavBarAppearance()
         registerTableViewClasses()
-        setupBarButton()
         addObservers()
     }
 
 // MARK: - Setup Functions
 
     private func setupUI() {
-        self.title = NSLocalizedString("Settings", comment: "")
-        self.tabBarItem = UITabBarItem(title: NSLocalizedString("Settings", comment: ""),
-                                       image: UIImage(named: "Settings"),
-                                       selectedImage: UIImage(named: "Settings"))
-        self.tabBarItem.accessibilityIdentifier = VLCAccessibilityIdentifier.settings
+        title = NSLocalizedString("Settings", comment: "")
+        tabBarItem = UITabBarItem(title: NSLocalizedString("Settings", comment: ""),
+                                  image: UIImage(named: "Settings"),
+                                  selectedImage: UIImage(named: "Settings"))
+        tabBarItem.accessibilityIdentifier = VLCAccessibilityIdentifier.settings
         tableView.separatorStyle = .none
         tableView.cellLayoutMarginsFollowReadableWidth = false //Fix for iPad
-        view.backgroundColor = PresentationTheme.current.colors.background
         actionSheet.modalPresentationStyle = .custom
+        themeDidChange()
         guard let localDict = getLocaleDictionary() else { return }
         localeDictionary = localDict
     }
@@ -100,7 +98,7 @@ class SettingsController: UITableViewController {
                                              action: #selector(showAbout))
         aboutBarButton.tintColor = PresentationTheme.current.colors.orangeUI
         navigationItem.leftBarButtonItem = aboutBarButton
-        self.navigationItem.leftBarButtonItem?.accessibilityIdentifier = VLCAccessibilityIdentifier.about
+        navigationItem.leftBarButtonItem?.accessibilityIdentifier = VLCAccessibilityIdentifier.about
 
         let tipJarBarButton = UIBarButtonItem(title: NSLocalizedString("GIVE_TIP", comment: ""),
                                              style: .plain,
@@ -108,14 +106,6 @@ class SettingsController: UITableViewController {
                                              action: #selector(showTipJar))
         aboutBarButton.tintColor = PresentationTheme.current.colors.orangeUI
         navigationItem.rightBarButtonItem = tipJarBarButton
-    }
-
-    private func setNavBarAppearance() {
-        if #available(iOS 13.0, *) {
-            let navigationBarAppearance = AppearanceManager.navigationbarAppearance
-            self.navigationController?.navigationBar.standardAppearance = navigationBarAppearance()
-            self.navigationController?.navigationBar.scrollEdgeAppearance = navigationBarAppearance()
-        }
     }
 
 // MARK: - Observer & BarButton Actions
@@ -139,9 +129,9 @@ class SettingsController: UITableViewController {
     }
 
     @objc private func themeDidChange() {
-        self.view.backgroundColor = PresentationTheme.current.colors.background
-        setNavBarAppearance()
-        self.setNeedsStatusBarAppearanceUpdate()
+        setupBarButton()
+        view.backgroundColor = PresentationTheme.current.colors.background
+        setNeedsStatusBarAppearanceUpdate()
     }
 
     @objc private func miniPlayerIsShown() {

--- a/Sources/TabBarCoordinator.swift
+++ b/Sources/TabBarCoordinator.swift
@@ -33,27 +33,12 @@ class TabBarCoordinator: NSObject {
 
     @objc func updateTheme() {
         editToolbar.backgroundColor = PresentationTheme.current.colors.tabBarColor
-        //Setting this in appearanceManager doesn't update tabbar and UINavigationbar of the settingsViewController on change hence we do it here
+        //Setting this in appearanceManager doesn't update tabbar on change hence we do it here
         tabBarController.tabBar.isTranslucent = false
         tabBarController.tabBar.backgroundColor = PresentationTheme.current.colors.tabBarColor
         tabBarController.tabBar.barTintColor = PresentationTheme.current.colors.tabBarColor
         tabBarController.tabBar.itemPositioning = .fill
-        tabBarController.viewControllers?.forEach {
-            if let navController = $0 as? UINavigationController, navController.topViewController is SettingsController {
-                navController.navigationBar.isTranslucent = false
-                navController.navigationBar.barTintColor = PresentationTheme.current.colors.navigationbarColor
-                navController.navigationBar.tintColor = PresentationTheme.current.colors.orangeUI
-                navController.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
-
-                if #available(iOS 11.0, *) {
-                    navController.navigationBar.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor:  PresentationTheme.current.colors.navigationbarTextColor]
-                }
-                if #available(iOS 13.0, *) {
-                    navController.navigationBar.standardAppearance = AppearanceManager.navigationbarAppearance()
-                    navController.navigationBar.scrollEdgeAppearance = AppearanceManager.navigationbarAppearance()
-                }
-            }
-        }
+        tabBarController.setNeedsStatusBarAppearanceUpdate()
     }
 
     private func setupViewControllers() {

--- a/Sources/VLCCloudStorageTableViewController.m
+++ b/Sources/VLCCloudStorageTableViewController.m
@@ -61,8 +61,6 @@
     _numberOfFilesBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"NUM_OF_FILES", nil), 0] style:UIBarButtonItemStylePlain target:nil action:nil];
     _sortBarButtonItem = [[UIBarButtonItem alloc] initWithTitle: [NSString stringWithFormat:NSLocalizedString(@"SORT", nil), 0]
                                                           style:UIBarButtonItemStylePlain target:self action:@selector(sortButtonClicked:)];
-    _sortBarButtonItem.tintColor = PresentationTheme.current.colors.orangeUI;
-    _numberOfFilesBarButtonItem.tintColor = PresentationTheme.current.colors.orangeUI;
 
     _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
     _activityIndicator.hidesWhenStopped = YES;
@@ -75,8 +73,6 @@
 
     _progressView = [VLCProgressView new];
     _progressBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:_progressView];
-    _progressView.tintColor = PresentationTheme.current.colors.orangeUI;
-    _progressView.progressLabel.textColor = PresentationTheme.current.colors.cellTextColor;
     
     sheet = [[VLCActionSheet alloc] init];
     manager = [[VLCCloudSortingSpecifierManager alloc] initWithController: self];
@@ -91,6 +87,8 @@
 
 - (void)updateForTheme
 {
+    _sortBarButtonItem.tintColor = PresentationTheme.current.colors.orangeUI;
+    _numberOfFilesBarButtonItem.tintColor = PresentationTheme.current.colors.orangeUI;
     self.tableView.separatorColor = PresentationTheme.current.colors.background;
     self.tableView.backgroundColor = PresentationTheme.current.colors.background;
     self.view.backgroundColor = PresentationTheme.current.colors.background;
@@ -98,7 +96,9 @@
     _activityIndicator.activityIndicatorViewStyle = PresentationTheme.current == PresentationTheme.brightTheme ? UIActivityIndicatorViewStyleGray : UIActivityIndicatorViewStyleWhiteLarge;
     self.loginToCloudStorageView.backgroundColor = PresentationTheme.current.colors.background;
     self.navigationController.toolbar.barStyle = PresentationTheme.current.colors.toolBarStyle;
+    _progressView.tintColor = PresentationTheme.current.colors.orangeUI;
     _progressView.progressLabel.textColor = PresentationTheme.current.colors.cellTextColor;
+    [self.tableView reloadData];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Sources/VLCFirstStepsViewController.m
+++ b/Sources/VLCFirstStepsViewController.m
@@ -69,11 +69,7 @@
 - (void)updateTheme
 {
     self.view.backgroundColor = PresentationTheme.current.colors.background;
-    if (@available(iOS 13.0, *)) {
-        UINavigationBarAppearance *navigationBarAppearance = [VLCAppearanceManager navigationbarAppearance];
-        self.navigationController.navigationBar.standardAppearance = navigationBarAppearance;
-        self.navigationController.navigationBar.scrollEdgeAppearance = navigationBarAppearance;
-    }
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle


### PR DESCRIPTION
https://code.videolan.org/videolan/vlc-ios/-/issues/913

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Working on FirstSteps screen I noticed that after going background (only without debugger) navigation bar changed background color. I also got this behavior in production VLC version (as it is also without debugger). So I experimented a lot - and achieved it with manual `themeUpdate` call in `UINavigationController`.
That's the most important part.

I can provide much more details if necessary. Feel free to answer.
