### PR TITLE
902 : refresh after onedrive login

### DIFF
--- a/Sources/VLCOneDriveConstants.h
+++ b/Sources/VLCOneDriveConstants.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * VLCDropboxConstants.h
+ * VLCOneDriveConstants.h
  * VLC for iOS
  *****************************************************************************
  * Copyright (c) 2019 VideoLAN. All rights reserved.

--- a/Sources/VLCOneDriveController.m
+++ b/Sources/VLCOneDriveController.m
@@ -122,24 +122,33 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     return _oneDriveClient != nil;
 }
 
+- (void)sessionWasUpdated
+{
+    if (self.delegate) {
+        if ([self.delegate respondsToSelector:@selector(sessionWasUpdated)])
+            [self.delegate performSelector:@selector(sessionWasUpdated)];
+    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:VLCOneDriveControllerSessionUpdated object:self];
+}
+
 - (void)authSuccess
 {
     APLog(@"VLCOneDriveController: Authentication complete.");
 
     [self setupSession];
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:VLCOneDriveControllerSessionUpdated object:self];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self sessionWasUpdated];
+    });
 }
 
 - (void)authFailed:(NSError *)error
 {
     APLog(@"VLCOneDriveController: Authentication failure.");
 
-    if (self.delegate) {
-        if ([self.delegate respondsToSelector:@selector(sessionWasUpdated)])
-            [self.delegate performSelector:@selector(sessionWasUpdated)];
-    }
-    [[NSNotificationCenter defaultCenter] postNotificationName:VLCOneDriveControllerSessionUpdated object:self];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self sessionWasUpdated];
+    });
 }
 
 #pragma mark - listing


### PR DESCRIPTION
https://code.videolan.org/videolan/vlc-ios/-/issues/902

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Fixed bug - call session update after successful (and unsuccessful) login to OneDrive.
Previously it was only in auth failed - and in improper thread (leads to crash in success scenario - so I moved notification call into main thread)
