### PR TITLE
920 : onedrive login preferslargetitles NO

### DIFF
--- a/Sources/VLCOneDriveController.m
+++ b/Sources/VLCOneDriveController.m
@@ -83,7 +83,14 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 {
     _presentingViewController = presentingViewController;
 
+    if (@available(iOS 11.0, *)) {
+        [[UINavigationBar appearance] setPrefersLargeTitles:NO];
+    }
+
     [ODClient authenticatedClientWithCompletion:^(ODClient *client, NSError *error) {
+        if (@available(iOS 11.0, *)) {
+            [VLCAppearanceManager setupAppearanceWithTheme:PresentationTheme.current];
+        }
         if (error) {
             [self authFailed:error];
             return;


### PR DESCRIPTION
https://code.videolan.org/videolan/vlc-ios/-/issues/920

<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

Set prefersLargeTitles NO for all and reset back to theme values in completion.

tried to add viewControllers into `UINavigationBar.appearance(whenContainedInInstancesOf: [VLCPlaybackNavigationController.self]).prefersLargeTitles = false` array - but adding UINavigationController is too aggressive (requires more codebase changes) and ODAuthenticationViewController is too weak - large titles blink in the beginning and appear during text editing
