### PR TITLE
Bug/921 onedrive reset numberoffiles

### DIFF
--- a/Apple-TV/Playback/Playback Info/VLCPlaybackInfoChaptersTVViewController.m
+++ b/Apple-TV/Playback/Playback Info/VLCPlaybackInfoChaptersTVViewController.m
@@ -97,7 +97,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell*)cell;
+    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell *)cell;
     NSInteger row = indexPath.row;
     VLCPlaybackService *vpc = [VLCPlaybackService sharedInstance];
 
@@ -128,7 +128,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell*)cell;
+    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell *)cell;
     NSInteger row = indexPath.row;
 
     BOOL isSelected = [[VLCPlaybackService sharedInstance] indexOfCurrentChapter] == row;

--- a/Apple-TV/Playback/Playback Info/VLCPlaybackInfoTVAnimators.m
+++ b/Apple-TV/Playback/Playback Info/VLCPlaybackInfoTVAnimators.m
@@ -92,7 +92,7 @@
 
     VLCPlaybackInfoTVViewController *infoVC = nil;
     if ([target isKindOfClass:[VLCPlaybackInfoTVViewController class]]) {
-        infoVC = (VLCPlaybackInfoTVViewController*) target;
+        infoVC = (VLCPlaybackInfoTVViewController *) target;
         infoVC.dimmingView.alpha = 0.0;
         targetAlpha = 1.0;
         toFrame = smallFrame;
@@ -100,7 +100,7 @@
         [container addSubview:target.view];
         [target.view layoutIfNeeded];
     } else if ([source isKindOfClass:[VLCPlaybackInfoTVViewController class]]) {
-        infoVC = (VLCPlaybackInfoTVViewController*) source;
+        infoVC = (VLCPlaybackInfoTVViewController *) source;
         infoVC.dimmingView.alpha = 1.0;
         targetAlpha = 0.0;
         toFrame = largeFrame;

--- a/Apple-TV/Playback/Playback Info/VLCPlaybackInfoTracksTVViewController.m
+++ b/Apple-TV/Playback/Playback Info/VLCPlaybackInfoTracksTVViewController.m
@@ -100,7 +100,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell*)cell;
+    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell *)cell;
     VLCPlaybackService *vpc = [VLCPlaybackService sharedInstance];
     NSInteger row = indexPath.row;
     NSString *trackName;
@@ -155,7 +155,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell*)cell;
+    VLCPlaybackInfoTVCollectionViewCell *trackCell = (VLCPlaybackInfoTVCollectionViewCell *)cell;
     VLCPlaybackService *vpc = [VLCPlaybackService sharedInstance];
     NSInteger row = indexPath.row;
     NSString *trackName;

--- a/Apple-TV/Playback/VLCFullscreenMovieTVViewController.m
+++ b/Apple-TV/Playback/VLCFullscreenMovieTVViewController.m
@@ -987,7 +987,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
     [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
 }
 
-- (void)displayLinkTriggered:(CADisplayLink*)link
+- (void)displayLinkTriggered:(CADisplayLink *)link
 {
     UIScrollView *scrollView = self.audioDescriptionTextView;
     CGFloat viewHeight = CGRectGetHeight(scrollView.frame);

--- a/Apple-TV/VLCAboutViewController.m
+++ b/Apple-TV/VLCAboutViewController.m
@@ -110,7 +110,7 @@
     [displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
 }
 
-- (void)displayLinkTriggered:(CADisplayLink*)link
+- (void)displayLinkTriggered:(CADisplayLink *)link
 {
     UIScrollView *scrollView = self.blablaTextView;
     CGFloat viewHeight = CGRectGetHeight(scrollView.frame);

--- a/Apple-TV/VLCCloudStorageTVViewController.m
+++ b/Apple-TV/VLCCloudStorageTVViewController.m
@@ -45,11 +45,13 @@
     }
 
     //reload if we didn't come back from streaming
-    if (self.currentPath == nil)
+    if (self.currentPath == nil) {
         self.currentPath = @"";
+    }
 
-    if([self.controller.currentListFiles count] == 0)
+    if ([self.controller.currentListFiles count] == 0) {
         [self requestInformationForCurrentPath];
+    }
 }
 
 - (void)requestInformationForCurrentPath

--- a/Apple-TV/VLCServerListTVViewController.m
+++ b/Apple-TV/VLCServerListTVViewController.m
@@ -173,7 +173,9 @@
 
     if ([service respondsToSelector:@selector(loginInformation)]) {
         VLCNetworkServerLoginInformation *login = service.loginInformation;
-        if (!login) return;
+        if (!login) {
+            return;
+        }
 
         /* UPnP does not support authentication, so skip this step */
         if ([login.protocolIdentifier isEqualToString:VLCNetworkServerProtocolIdentifierUPnP]) {
@@ -203,7 +205,9 @@
     if ([service respondsToSelector:@selector(directPlaybackURL)]) {
 
         NSURL *url = service.directPlaybackURL;
-        if (!url) return;
+        if (!url) {
+            return;
+        }
 
         VLCMediaList *medialist = [[VLCMediaList alloc] init];
         [medialist addMedia:[VLCMedia mediaWithURL:url]];

--- a/SharedSources/Clouds/VLCBoxCollectionViewController.m
+++ b/SharedSources/Clouds/VLCBoxCollectionViewController.m
@@ -66,8 +66,9 @@
     self.controller = _boxController;
     self.controller.delegate = self;
 
-    if (!_listOfFiles || _listOfFiles.count == 0)
+    if (!_listOfFiles || _listOfFiles.count == 0) {
         [self requestInformationForCurrentPath];
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -107,17 +108,19 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.row >= _listOfFiles.count)
+    if (indexPath.row >= _listOfFiles.count) {
         return;
+    }
 
     _selectedFile = _listOfFiles[indexPath.row];
-    if (![_selectedFile.type isEqualToString:@"folder"])
+    if (![_selectedFile.type isEqualToString:@"folder"]) {
         [self streamFile:(BoxFile *)_selectedFile];
-    else {
+    } else {
         /* dive into subdirectory */
         NSString *path = self.currentPath;
-        if (![path isEqualToString:@""])
+        if (![path isEqualToString:@""]) {
             path = [path stringByAppendingString:@"/"];
+        }
         path = [path stringByAppendingString:_selectedFile.modelID];
 
         VLCBoxCollectionViewController *targetViewController = [[VLCBoxCollectionViewController alloc] initWithPath:path];

--- a/SharedSources/Clouds/VLCDropboxCollectionViewController.m
+++ b/SharedSources/Clouds/VLCDropboxCollectionViewController.m
@@ -73,9 +73,9 @@
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     _selectedFile = _mediaList[indexPath.row];
-    if (![_selectedFile isKindOfClass:[DBFILESFolderMetadata class]])
+    if (![_selectedFile isKindOfClass:[DBFILESFolderMetadata class]]) {
         [_dropboxController streamFile:_selectedFile currentNavigationController:self.navigationController];
-    else {
+    } else {
         /* dive into subdirectory */
         NSString *futurePath = [self.currentPath stringByAppendingFormat:@"/%@", _selectedFile.name];
         [_dropboxController reset];

--- a/SharedSources/Clouds/VLCOneDriveCollectionViewController.m
+++ b/SharedSources/Clouds/VLCOneDriveCollectionViewController.m
@@ -42,10 +42,11 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    if (_currentFolder != nil)
+    if (_currentFolder != nil) {
         self.title = _currentFolder.name;
-    else
+    } else {
         self.title = @"OneDrive";
+    }
 
     [self updateViewAfterSessionChange];
     self.authorizationInProgress = NO;
@@ -64,8 +65,9 @@
 {
     VLCRemoteBrowsingTVCell *cell = (VLCRemoteBrowsingTVCell *)[collectionView dequeueReusableCellWithReuseIdentifier:VLCRemoteBrowsingTVCellIdentifier forIndexPath:indexPath];
 
-    if (_currentFolder == nil)
+    if (_currentFolder == nil) {
         _currentFolder = _oneDriveController.rootFolder;
+    }
 
     if (_currentFolder) {
         NSArray *items = _currentFolder.items;
@@ -80,13 +82,15 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (_currentFolder == nil)
+    if (_currentFolder == nil) {
         return;
+    }
 
     NSArray *folderItems = _currentFolder.items;
     NSInteger row = indexPath.row;
-    if (row >= folderItems.count)
+    if (row >= folderItems.count) {
         return;
+    }
 
     VLCOneDriveObject *selectedObject = folderItems[row];
     if (selectedObject.isFolder) {

--- a/SharedSources/Imported/OROpenSubtitleDownloader.m
+++ b/SharedSources/Imported/OROpenSubtitleDownloader.m
@@ -222,7 +222,7 @@ static NSString * const kRequest_SearchSubtitles = @"SearchSubtitles";
 #pragma mark -
 #pragma mark XMLRPC delegate methods
 
-- (void)request: (XMLRPCRequest *)request didReceiveResponse:(XMLRPCResponse *)response {
+- (void)request:(XMLRPCRequest *)request didReceiveResponse:(XMLRPCResponse *)response {
     // Nothing will work without a valid user agent.
     NSString *status = response.object[@"status"];
     if ([status isEqualToString:@"414 Unknown User Agent"]) {
@@ -288,7 +288,7 @@ static NSString * const kRequest_SearchSubtitles = @"SearchSubtitles";
     }
 }
 
-- (void)request: (XMLRPCRequest *)request didFailWithError: (NSError *)error {
+- (void)request:(XMLRPCRequest *)request didFailWithError:(NSError *)error {
     NSLog(@"%@ - %@", NSStringFromSelector(_cmd), error.localizedDescription);
 
     // Languages search
@@ -316,15 +316,15 @@ static NSString * const kRequest_SearchSubtitles = @"SearchSubtitles";
     }
 }
 
-- (BOOL)request: (XMLRPCRequest *)request canAuthenticateAgainstProtectionSpace: (NSURLProtectionSpace *)protectionSpace {
+- (BOOL)request:(XMLRPCRequest *)request canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace {
     return YES;
 }
 
-- (void)request: (XMLRPCRequest *)request didReceiveAuthenticationChallenge: (NSURLAuthenticationChallenge *)challenge {
+- (void)request:(XMLRPCRequest *)request didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
     NSLog(@"%@ - %@", NSStringFromSelector(_cmd), challenge);
 }
 
-- (void)request: (XMLRPCRequest *)request didCancelAuthenticationChallenge: (NSURLAuthenticationChallenge *)challenge {
+- (void)request:(XMLRPCRequest *)request didCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
     NSLog(@"%@ - %@", NSStringFromSelector(_cmd), challenge);
 }
 

--- a/SharedSources/Imported/OROpenSubtitleDownloader.m
+++ b/SharedSources/Imported/OROpenSubtitleDownloader.m
@@ -42,7 +42,9 @@ static NSString * const kRequest_SearchSubtitles = @"SearchSubtitles";
 - (OROpenSubtitleDownloader *)initWithUserAgent:(NSString *)userAgent delegate:(id<OROpenSubtitleDownloaderDelegate>) delegate
 {
     self = [super init];
-    if (!self) return nil;
+    if (!self) {
+        return nil;
+    }
 
     _delegate = delegate;
     _userAgent = userAgent;

--- a/SharedSources/Imported/Reachability.m
+++ b/SharedSources/Imported/Reachability.m
@@ -91,7 +91,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 {
 #pragma unused (target, flags)
 	NSCAssert(info != NULL, @"info was NULL in ReachabilityCallback");
-	NSCAssert([(__bridge NSObject*) info isKindOfClass: [Reachability class]], @"info was wrong class in ReachabilityCallback");
+	NSCAssert([(__bridge NSObject *) info isKindOfClass: [Reachability class]], @"info was wrong class in ReachabilityCallback");
 
     Reachability* noteObject = (__bridge Reachability *)info;
     // Post a notification to notify the client that the network reachability changed.

--- a/SharedSources/ServerBrowsing/Bonjour/VLCLocalNetworkServiceBrowserBonjour.h
+++ b/SharedSources/ServerBrowsing/Bonjour/VLCLocalNetworkServiceBrowserBonjour.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 extern NSString *const VLCNetworkServerProtocolIdentifierBonjour;
-@interface VLCLocalNetworkServiceBonjour: VLCLocalNetworkServiceVLCMedia
+@interface VLCLocalNetworkServiceBonjour : VLCLocalNetworkServiceVLCMedia
 
 @end
 

--- a/SharedSources/ServerBrowsing/General/VLCDownloadController.m
+++ b/SharedSources/ServerBrowsing/General/VLCDownloadController.m
@@ -64,7 +64,7 @@
 }
 
 #pragma mark - API to other VLC objects
-- (void)addURLToDownloadList:(NSURL *)aURL fileNameOfMedia:(NSString*)fileName
+- (void)addURLToDownloadList:(NSURL *)aURL fileNameOfMedia:(NSString *)fileName
 {
     VLCMedia *media = [VLCMedia mediaWithURL:aURL];
     @synchronized (_currentDownloads) {
@@ -73,7 +73,7 @@
     [self _updateDownloadList];
 }
 
-- (void)addVLCMediaToDownloadList:(VLCMedia *)media fileNameOfMedia:(NSString*)fileName expectedDownloadSize:(long long unsigned)expectedDownloadSize
+- (void)addVLCMediaToDownloadList:(VLCMedia *)media fileNameOfMedia:(NSString *)fileName expectedDownloadSize:(long long unsigned)expectedDownloadSize
 {
     @synchronized (_currentDownloads) {
         [_currentDownloads addObject:media];

--- a/SharedSources/ServerBrowsing/General/VLCLocalNetworkServiceBrowserNetService.m
+++ b/SharedSources/ServerBrowsing/General/VLCLocalNetworkServiceBrowserNetService.m
@@ -13,15 +13,17 @@
 #import "VLCLocalNetworkServiceBrowserNetService.h"
 
 @interface NSMutableArray(VLCLocalNetworkServiceNetService)
--(NSUInteger)vlc_indexOfServiceWithNetService:(NSNetService*)netService;
--(void)vlc_removeServiceWithNetService:(NSNetService*)netService;
+-(NSUInteger)vlc_indexOfServiceWithNetService:(NSNetService *)netService;
+-(void)vlc_removeServiceWithNetService:(NSNetService *)netService;
 
 @end
 @implementation NSMutableArray (VLCLocalNetworkServiceNetService)
 
 - (NSUInteger)vlc_indexOfServiceWithNetService:(NSNetService *)netService {
     NSUInteger index = [self indexOfObjectPassingTest:^BOOL(VLCLocalNetworkServiceNetService *obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        if (![obj respondsToSelector:@selector(netService)]) return false;
+        if (![obj respondsToSelector:@selector(netService)]) {
+            return false;
+        }
         BOOL equal = [obj.netService isEqual:netService];
         if (equal) {
             *stop = YES;

--- a/SharedSources/ServerBrowsing/NFS/VLCLocalNetworkServiceBrowserNFS.h
+++ b/SharedSources/ServerBrowsing/NFS/VLCLocalNetworkServiceBrowserNFS.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 extern NSString *const VLCNetworkServerProtocolIdentifierNFS;
-@interface VLCLocalNetworkServiceNFS: VLCLocalNetworkServiceVLCMedia
+@interface VLCLocalNetworkServiceNFS : VLCLocalNetworkServiceVLCMedia
 
 @end
 

--- a/SharedSources/ServerBrowsing/Plex/VLCPlexWebAPI.h
+++ b/SharedSources/ServerBrowsing/Plex/VLCPlexWebAPI.h
@@ -17,7 +17,7 @@
 - (NSString *)urlAuth:(NSString *)url authentification:(NSString *)auth;
 - (void)stopSession:(NSString *)adress port:(NSString *)port session:(NSString *)session;
 - (NSInteger)MarkWatchedUnwatchedMedia:(NSString *)address port:(NSString *)port videoRatingKey:(NSString *)ratingKey state:(NSString *)state authentification:(NSString *)auth;
-- (NSString *)getFileSubtitleFromPlexServer:(NSDictionary *)mediaObject modeStream:(BOOL)modeStream error:(NSError *__autoreleasing*)error;
+- (NSString *)getFileSubtitleFromPlexServer:(NSDictionary *)mediaObject modeStream:(BOOL)modeStream error:(NSError *__autoreleasing *)error;
 - (NSString *)getSession;
 
 + (NSString *)urlAuth:(NSString *)url authentification:(NSString *)auth;

--- a/SharedSources/ServerBrowsing/SAP/VLCLocalNetworkServiceBrowserSAP.h
+++ b/SharedSources/ServerBrowsing/SAP/VLCLocalNetworkServiceBrowserSAP.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface VLCLocalNetworkServiceSAP: VLCLocalNetworkServiceVLCMedia
+@interface VLCLocalNetworkServiceSAP : VLCLocalNetworkServiceVLCMedia
 
 @end
 

--- a/SharedSources/ServerBrowsing/SMB/VLCLocalNetworkServiceBrowserDSM.h
+++ b/SharedSources/ServerBrowsing/SMB/VLCLocalNetworkServiceBrowserDSM.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 extern NSString *const VLCNetworkServerProtocolIdentifierSMB;
-@interface VLCLocalNetworkServiceDSM: VLCLocalNetworkServiceVLCMedia
+@interface VLCLocalNetworkServiceDSM : VLCLocalNetworkServiceVLCMedia
 
 @end
 

--- a/SharedSources/VLCMetadata.h
+++ b/SharedSources/VLCMetadata.h
@@ -10,7 +10,7 @@
  *****************************************************************************/
 
 @class VLCMLMedia;
-@interface VLCMetaData: NSObject
+@interface VLCMetaData : NSObject
 
 @property(readwrite, copy) NSString *title;
 @property(readwrite) UIImage *artworkImage;

--- a/SharedSources/VLCMetadata.h
+++ b/SharedSources/VLCMetadata.h
@@ -23,7 +23,7 @@
 @property(readwrite) NSNumber *playbackRate;
 
 #if TARGET_OS_IOS
-- (void)updateMetadataFromMedia:(VLCMLMedia *)media mediaPlayer:(VLCMediaPlayer*)mediaPlayer;
+- (void)updateMetadataFromMedia:(VLCMLMedia *)media mediaPlayer:(VLCMediaPlayer *)mediaPlayer;
 #else
 - (void)updateMetadataFromMediaPlayer:(VLCMediaPlayer *)mediaPlayer;
 #endif

--- a/SharedSources/VLCMetadata.m
+++ b/SharedSources/VLCMetadata.m
@@ -40,7 +40,7 @@
 #endif
 
 #if TARGET_OS_IOS
-- (void)updateMetadataFromMedia:(VLCMLMedia *)media mediaPlayer:(VLCMediaPlayer*)mediaPlayer
+- (void)updateMetadataFromMedia:(VLCMLMedia *)media mediaPlayer:(VLCMediaPlayer *)mediaPlayer
 {
     if (media) {
         self.title = media.title;
@@ -72,7 +72,9 @@
     [self updatePlaybackRate:mediaPlayer];
 
     //Down here because we still need to populate the miniplayer
-    if ([VLCKeychainCoordinator passcodeLockEnabled]) return;
+    if ([VLCKeychainCoordinator passcodeLockEnabled]) {
+        return;
+    }
 
     [self populateInfoCenterFromMetadata];
 }

--- a/SharedSources/VLCRemoteControlService.m
+++ b/SharedSources/VLCRemoteControlService.m
@@ -86,7 +86,9 @@ static inline NSArray * RemoteCommandCenterCommandsToHandle()
 
 - (MPRemoteCommandHandlerStatus )remoteCommandEvent:(MPRemoteCommandEvent *)event
 {
-    if (!_remoteControlServiceDelegate) return MPRemoteCommandHandlerStatusCommandFailed;
+    if (!_remoteControlServiceDelegate) {
+        return MPRemoteCommandHandlerStatusCommandFailed;
+    }
 
     MPRemoteCommandCenter *cc = [MPRemoteCommandCenter sharedCommandCenter];
 

--- a/Sources/Extensions/UIImage+Blur.m
+++ b/Sources/Extensions/UIImage+Blur.m
@@ -47,7 +47,7 @@
     inBuffer.width = CGImageGetWidth(rawImage);
     inBuffer.height = CGImageGetHeight(rawImage);
     inBuffer.rowBytes = CGImageGetBytesPerRow(rawImage);
-    inBuffer.data = (void*)CFDataGetBytePtr(inBitmapData);
+    inBuffer.data = (void *)CFDataGetBytePtr(inBitmapData);
 
     pixelBuffer = malloc(CGImageGetBytesPerRow(rawImage) * CGImageGetHeight(rawImage));
 

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginDataSourceProtocol.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginDataSourceProtocol.m
@@ -15,7 +15,7 @@
 
 static NSString *const VLCNetworkLoginDataSourceProtocolCellIdentifier = @"VLCNetworkLoginDataSourceProtocolCell";
 
-@interface  VLCNetworkLoginDataSourceProtocolCell : UITableViewCell
+@interface  VLCNetworkLoginDataSourceProtocolCell: UITableViewCell
 @property (nonatomic) UISegmentedControl *segmentedControl;
 @end
 

--- a/Sources/LocalNetworkConnectivity/VLCNetworkLoginDataSourceSavedLogins.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkLoginDataSourceSavedLogins.m
@@ -102,7 +102,7 @@ static NSString *const VLCNetworkLoginSavedLoginCellIdentifier = @"VLCNetworkLog
 {
     NSError *innerError = nil;
     BOOL success = [login saveLoginInformationToKeychainWithError:&innerError];
-    if(!success) {
+    if (!success) {
         NSLog(@"Failed to save login with error: %@",innerError);
         if (error) {
             *error = innerError;

--- a/Sources/LocalNetworkConnectivity/VLCNetworkServerBrowserViewController.m
+++ b/Sources/LocalNetworkConnectivity/VLCNetworkServerBrowserViewController.m
@@ -208,7 +208,7 @@
 {
     [super tableView:tableView willDisplayCell:cell forRowAtIndexPath:indexPath];
 
-    if([indexPath row] == ((NSIndexPath*)[[tableView indexPathsForVisibleRows] lastObject]).row)
+    if ([indexPath row] == ((NSIndexPath *)[[tableView indexPathsForVisibleRows] lastObject]).row)
         [[VLCActivityManager defaultManager] networkActivityStopped];
 
     cell.titleLabel.textColor = cell.folderTitleLabel.textColor = cell.subtitleLabel.textColor = cell.thumbnailView.tintColor = PresentationTheme.current.colors.cellTextColor;

--- a/Sources/Playback/VLCMovieViewController.m
+++ b/Sources/Playback/VLCMovieViewController.m
@@ -367,8 +367,8 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
 
     // HACK: get the slider from volume view
     UISlider *volumeSlider = nil;
-    for (id aView in _controllerPanel.volumeView.subviews){
-        if ([aView isKindOfClass:[UISlider class]]){
+    for (id aView in _controllerPanel.volumeView.subviews) {
+        if ([aView isKindOfClass:[UISlider class]]) {
             volumeSlider = (UISlider *)aView;
             break;
         }
@@ -400,7 +400,7 @@ typedef NS_ENUM(NSInteger, VLCPanType) {
 {
     float margin = 40.0f;
     UILayoutGuide *guide = self.view.layoutMarginsGuide;
-    if(@available(iOS 11.0, *)) {
+    if (@available(iOS 11.0, *)) {
         guide = self.view.safeAreaLayoutGuide;
     }
     return @[[_videoPlayerMainControl.bottomAnchor
@@ -1546,7 +1546,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
             } else {
                 control.enabled = !_interfaceIsLocked;
             }
-        } else if ([item isKindOfClass:[UIGestureRecognizer class]]){
+        } else if ([item isKindOfClass:[UIGestureRecognizer class]]) {
             UIGestureRecognizer *gestureRecognizer = (UIGestureRecognizer *)item;
             gestureRecognizer.enabled = !_interfaceIsLocked;
         } else if ([item isKindOfClass:[VLCVolumeView class]]) {
@@ -1554,7 +1554,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
             VLCVolumeView *view = (VLCVolumeView *)item;
             view.userInteractionEnabled = !_interfaceIsLocked;
             view.alpha = _interfaceIsLocked ? 0.5 : 1;
-        } else if(@available(iOS 11.0, *)){
+        } else if (@available(iOS 11.0, *)) {
             if ([item isKindOfClass:[AVRoutePickerView class]]) {
                 AVRoutePickerView *airplayView = (AVRoutePickerView *)item;
                 airplayView.userInteractionEnabled = !_interfaceIsLocked;
@@ -1675,7 +1675,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
     return YES;
 }
 
-- (VLCPanType)detectPanTypeForPan:(UIPanGestureRecognizer*)panRecognizer
+- (VLCPanType)detectPanTypeForPan:(UIPanGestureRecognizer *)panRecognizer
 {
     NSString *deviceType = [[UIDevice currentDevice] model];
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];
@@ -1698,7 +1698,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
     return panType;
 }
 
-- (void)panRecognized:(UIPanGestureRecognizer*)panRecognizer
+- (void)panRecognized:(UIPanGestureRecognizer *)panRecognizer
 {
     CGFloat panDirectionX = [panRecognizer velocityInView:self.view].x;
     CGFloat panDirectionY = [panRecognizer velocityInView:self.view].y;
@@ -1792,7 +1792,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
     [self applyYaw:diffYaw pitch:diffPitch];
 }
 
-- (void)swipeRecognized:(UISwipeGestureRecognizer*)swipeRecognizer
+- (void)swipeRecognized:(UISwipeGestureRecognizer *)swipeRecognizer
 {
     if (!_swipeSeekGestureEnabled)
         return;
@@ -1886,7 +1886,7 @@ currentMediaHasTrackToChooseFrom:(BOOL)currentMediaHasTrackToChooseFrom
     //Handling seek reset if tap orientation changes.
     if (tapPosition.x < backwardBoundary) {
         _numberOfTapSeek = _previousJumpState == VLCMovieJumpStateForward ? -1 : _numberOfTapSeek - 1;
-    } else if (tapPosition.x > forwardBoundary){
+    } else if (tapPosition.x > forwardBoundary) {
         _numberOfTapSeek = _previousJumpState == VLCMovieJumpStateBackward ? 1 : _numberOfTapSeek + 1;
     } else {
         [_vpc switchAspectRatio:YES];

--- a/Sources/Playback/VLCTrackSelectorView.m
+++ b/Sources/Playback/VLCTrackSelectorView.m
@@ -88,7 +88,7 @@
     VLCPlaybackService *playbackController = [VLCPlaybackService sharedInstance];
 
     if (_switchingTracksNotChapters) {
-        if([playbackController numberOfAudioTracks] > 2)
+        if ([playbackController numberOfAudioTracks] > 2)
             sections++;
 
         if ([playbackController numberOfVideoSubtitlesIndexes] >= 1)
@@ -175,7 +175,7 @@
         if ([playbackController numberOfTitles] > 1 && section == 0) {
 
             NSDictionary *description = [playbackController titleDescriptionsDictAtIndex:row];
-            if(description != nil) {
+            if (description != nil) {
                 cell.textLabel.text = [NSString stringWithFormat:@"%@ (%@)", description[VLCTitleDescriptionName], [[VLCTime timeWithNumber:description[VLCTitleDescriptionDuration]] stringValue]];
             }
 

--- a/Sources/UIBarButtonItem+Theme.h
+++ b/Sources/UIBarButtonItem+Theme.h
@@ -11,6 +11,6 @@
  *****************************************************************************/
 @interface UIBarButtonItem (ThemedButtons)
 + (UIBarButtonItem *)themedBackButtonWithTarget:(id)target andSelector:(SEL)selector;
-+ (UIBarButtonItem *)themedDarkToolbarButtonWithTitle: (NSString *) title target:(id)target andSelector:(SEL)selector;
++ (UIBarButtonItem *)themedDarkToolbarButtonWithTitle:(NSString *)title target:(id)target andSelector:(SEL)selector;
 + (UIBarButtonItem *)themedPlayAllButtonWithTarget:(id)target andSelector:(SEL)selector;
 @end

--- a/Sources/UIBarButtonItem+Theme.h
+++ b/Sources/UIBarButtonItem+Theme.h
@@ -11,6 +11,6 @@
  *****************************************************************************/
 @interface UIBarButtonItem (ThemedButtons)
 + (UIBarButtonItem *)themedBackButtonWithTarget:(id)target andSelector:(SEL)selector;
-+ (UIBarButtonItem *)themedDarkToolbarButtonWithTitle: (NSString*) title target:(id)target andSelector:(SEL)selector;
++ (UIBarButtonItem *)themedDarkToolbarButtonWithTitle: (NSString *) title target:(id)target andSelector:(SEL)selector;
 + (UIBarButtonItem *)themedPlayAllButtonWithTarget:(id)target andSelector:(SEL)selector;
 @end

--- a/Sources/UIBarButtonItem+Theme.m
+++ b/Sources/UIBarButtonItem+Theme.m
@@ -26,7 +26,7 @@
     return backButton;
 }
 
-+ (UIBarButtonItem *)themedDarkToolbarButtonWithTitle:(NSString*)title target:(id)target andSelector:(SEL)selector
++ (UIBarButtonItem *)themedDarkToolbarButtonWithTitle:(NSString *)title target:(id)target andSelector:(SEL)selector
 {
     UIBarButtonItem *button = [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStylePlain target:target action:selector];
     button.tintColor = [UIColor whiteColor];

--- a/Sources/VLCAppDelegate.m
+++ b/Sources/VLCAppDelegate.m
@@ -154,7 +154,9 @@ continueUserActivity:(NSUserActivity *)userActivity
  restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *))restorationHandler
 {
     VLCMLMedia *media = [appCoordinator mediaForUserActivity:userActivity];
-    if (!media) return NO;
+    if (!media) {
+        return NO;
+    }
 
     [self validatePasscodeIfNeededWithCompletion:^{
         [[VLCPlaybackService sharedInstance] playMedia:media];
@@ -166,7 +168,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 didFailToContinueUserActivityWithType:(NSString *)userActivityType
               error:(NSError *)error
 {
-    if (error.code != NSUserCancelledError){
+    if (error.code != NSUserCancelledError) {
         //TODO: present alert
     }
 }
@@ -191,15 +193,15 @@ didFailToContinueUserActivityWithType:(NSString *)userActivityType
 - (void)applicationWillResignActive:(UIApplication *)application
 {
     //Touch ID is shown 
-    if ([_window.rootViewController.presentedViewController isKindOfClass:[UINavigationController class]]){
+    if ([_window.rootViewController.presentedViewController isKindOfClass:[UINavigationController class]]) {
         UINavigationController *navCon = (UINavigationController *)_window.rootViewController.presentedViewController;
-        if ([navCon.topViewController isKindOfClass:[PasscodeLockController class]]){
+        if ([navCon.topViewController isKindOfClass:[PasscodeLockController class]]) {
             return;
         }
     }
     [self validatePasscodeIfNeededWithCompletion:^{
         //TODO: handle updating the videoview and
-        if ([VLCPlaybackService sharedInstance].isPlaying){
+        if ([VLCPlaybackService sharedInstance].isPlaying) {
             //TODO: push playback
         }
     }];
@@ -212,7 +214,7 @@ didFailToContinueUserActivityWithType:(NSString *)userActivityType
         [[MLMediaLibrary sharedMediaLibrary] updateMediaDatabase];
       //  [[VLCMediaFileDiscoverer sharedInstance] updateMediaList];
         [[VLCPlaybackService sharedInstance] recoverDisplayedMetadata];
-    } else if(_isComingFromHandoff) {
+    } else if (_isComingFromHandoff) {
         _isComingFromHandoff = NO;
     }
 }

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -102,8 +102,9 @@
     [ubiquitousStore setString:nil forKey:kVLCStoreBoxCredentials];
     [ubiquitousStore synchronize];
     [self stopSession];
-    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
+    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
+    }
     if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
         [self.delegate mediaListReset];
     }
@@ -137,8 +138,9 @@
 - (void)requestDirectoryListingAtPath:(NSString *)path
 {
     //we entered a different folder so discard all current files
-    if (![path isEqualToString:_folderId])
+    if (![path isEqualToString:_folderId]) {
         _currentFileList = nil;
+    }
     [self listFilesWithID:path];
 }
 
@@ -175,16 +177,20 @@
 - (void)downloadFileToDocumentFolder:(BoxItem *)file
 {
     if (file != nil) {
-        if ([file.type isEqualToString:BoxAPIItemTypeFolder]) return;
+        if ([file.type isEqualToString:BoxAPIItemTypeFolder]) {
+            return;
+        }
 
-        if (!_listOfBoxFilesToDownload)
+        if (!_listOfBoxFilesToDownload) {
             _listOfBoxFilesToDownload = [NSMutableArray new];
+        }
 
         [_listOfBoxFilesToDownload addObject:file];
     }
 
-    if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)])
+    if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)]) {
         [self.delegate numberOfFilesWaitingToBeDownloadedChanged];
+    }
 
     [self _triggerNextDownload];
 }
@@ -195,8 +201,9 @@
         [self _reallyDownloadFileToDocumentFolder:_listOfBoxFilesToDownload[0]];
         [_listOfBoxFilesToDownload removeObjectAtIndex:0];
 
-        if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)])
+        if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)]) {
             [self.delegate numberOfFilesWaitingToBeDownloadedChanged];
+        }
     }
 }
 
@@ -208,8 +215,9 @@
     [self loadFile:file intoPath:[self createPotentialPathFrom:filePath]];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStarted)])
+        if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStarted)]) {
             [self.delegate operationWithProgressInformationStarted];
+        }
     });
     _downloadInProgress = YES;
 }
@@ -235,8 +243,9 @@
             supportedFile = [[NSString stringWithFormat:@".%@",file.name.lastPathComponent] isSupportedFormat];
         }
 
-       if (isDirectory || supportedFile)
+        if (isDirectory || supportedFile) {
             [listOfGoodFilesAndFolders addObject:boxFile];
+        }
     }
     _currentFileList = [_currentFileList count] ? [_currentFileList arrayByAddingObjectsFromArray:listOfGoodFilesAndFolders] : [NSArray arrayWithArray:listOfGoodFilesAndFolders];
 
@@ -247,12 +256,13 @@
 
     APLog(@"found filtered metadata for %lu files", (unsigned long)_currentFileList.count);
 
-    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
+    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
+    }
 }
 
 #if TARGET_OS_IOS
-- (void)loadFile:(BoxFile *)file intoPath:(NSString*)destinationPath
+- (void)loadFile:(BoxFile *)file intoPath:(NSString *)destinationPath
 {
     NSOutputStream *outputStream = [NSOutputStream outputStreamToFileAtPath:destinationPath append:NO];
     _startDL = [NSDate timeIntervalSinceReferenceDate];
@@ -277,8 +287,9 @@
         CGFloat progress = (CGFloat)bytesReceived / (CGFloat)expectedTotalBytes;
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            if ([self.delegate respondsToSelector:@selector(currentProgressInformation:)])
+            if ([self.delegate respondsToSelector:@selector(currentProgressInformation:)]) {
                 [self.delegate currentProgressInformation:progress];
+            }
         });
     };
 
@@ -309,8 +320,9 @@
     NSString *remainingTime = [formatter stringFromDate:date];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.delegate respondsToSelector:@selector(updateRemainingTime:)])
+        if ([self.delegate respondsToSelector:@selector(updateRemainingTime:)]) {
             [self.delegate updateRemainingTime:remainingTime];
+        }
     });
 }
 
@@ -326,20 +338,22 @@
                                                         object:self];
 #endif
     dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)])
+        if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)]) {
             [self.delegate operationWithProgressInformationStopped];
+        }
     });
     _downloadInProgress = NO;
 
     [self _triggerNextDownload];
 }
 
-- (void)downloadFailedWithError:(NSError*)error
+- (void)downloadFailedWithError:(NSError *)error
 {
     APLog(@"BoxFile download failed with error %li", (long)error.code);
     dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)])
+        if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)]) {
             [self.delegate operationWithProgressInformationStopped];
+        }
     });
     _downloadInProgress = NO;
 
@@ -356,9 +370,9 @@
 
 - (NSInteger)numberOfFilesWaitingToBeDownloaded
 {
-    if (_listOfBoxFilesToDownload)
+    if (_listOfBoxFilesToDownload) {
         return _listOfBoxFilesToDownload.count;
-
+    }
     return 0;
 }
 

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -104,6 +104,9 @@
     [self stopSession];
     if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
         [self.delegate mediaListUpdated];
+    if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
+        [self.delegate mediaListReset];
+    }
 }
 
 - (void)boxApiTokenDidRefresh

--- a/Sources/VLCBoxController.m
+++ b/Sources/VLCBoxController.m
@@ -105,9 +105,6 @@
     if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
     }
-    if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
-        [self.delegate mediaListReset];
-    }
 }
 
 - (void)boxApiTokenDidRefresh

--- a/Sources/VLCBoxTableViewController.m
+++ b/Sources/VLCBoxTableViewController.m
@@ -147,8 +147,9 @@
     static NSString *CellIdentifier = @"BoxCell";
 
     VLCCloudStorageTableViewCell *cell = (VLCCloudStorageTableViewCell *)[tableView dequeueReusableCellWithIdentifier:CellIdentifier];
-    if (cell == nil)
+    if (cell == nil) {
         cell = [VLCCloudStorageTableViewCell cellWithReuseIdentifier:CellIdentifier];
+    }
 
     NSUInteger index = indexPath.row;
     if (_listOfFiles) {
@@ -172,13 +173,14 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [self.tableView deselectRowAtIndexPath:indexPath animated:NO];
-    if (indexPath.row >= _listOfFiles.count)
+    if (indexPath.row >= _listOfFiles.count) {
         return;
+    }
 
     _selectedFile = _listOfFiles[indexPath.row];
-    if (![_selectedFile.type isEqualToString:@"folder"])
+    if (![_selectedFile.type isEqualToString:@"folder"]) {
         [self streamFile:(BoxFile *)_selectedFile];
-    else {
+    } else {
         /* dive into subdirectory */
         NSString *path = self.currentPath;
         if (![path isEqualToString:@""])

--- a/Sources/VLCCloudStorageController.h
+++ b/Sources/VLCCloudStorageController.h
@@ -17,7 +17,6 @@ typedef NS_ENUM (NSInteger, VLCCloudSortingCriteria) {
 
 @required
 - (void)mediaListUpdated;
-- (void)mediaListReset;
 
 @optional
 - (void)operationWithProgressInformationStarted;

--- a/Sources/VLCCloudStorageController.h
+++ b/Sources/VLCCloudStorageController.h
@@ -17,6 +17,7 @@ typedef NS_ENUM (NSInteger, VLCCloudSortingCriteria) {
 
 @required
 - (void)mediaListUpdated;
+- (void)mediaListReset;
 
 @optional
 - (void)operationWithProgressInformationStarted;

--- a/Sources/VLCCloudStorageController.m
+++ b/Sources/VLCCloudStorageController.m
@@ -19,7 +19,7 @@
 }
 - (void)logout
 {
-    // nop
+    _currentListFiles = @[];
 }
 - (void)requestDirectoryListingAtPath:(NSString *)path
 {

--- a/Sources/VLCCloudStorageTableViewController.m
+++ b/Sources/VLCCloudStorageTableViewController.m
@@ -150,19 +150,21 @@
     [self.tableView reloadData];
 
     NSUInteger count = self.controller.currentListFiles.count;
-    if (count == 0)
+    if (count == 0) {
         self.numberOfFilesBarButtonItem.title = NSLocalizedString(@"NO_FILES", nil);
-    else if (count != 1)
+    } else if (count != 1) {
         self.numberOfFilesBarButtonItem.title = [NSString stringWithFormat:NSLocalizedString(@"NUM_OF_FILES", nil), count];
-    else
+    } else {
         self.numberOfFilesBarButtonItem.title = NSLocalizedString(@"ONE_FILE", nil);
+    }
+}
 
 - (void)mediaListReset
 {
     self.numberOfFilesBarButtonItem.title = [NSString stringWithFormat:NSLocalizedString(@"NUM_OF_FILES", nil), 0];
 }
 
-- (NSArray*)_generateToolbarItemsWithSortButton : (BOOL)withsb
+- (NSArray *)_generateToolbarItemsWithSortButton : (BOOL)withsb
 {
     NSMutableArray* result = [NSMutableArray array];
     if (withsb)
@@ -178,8 +180,7 @@
     if (!value) {
         [self setToolbarItems:[self _generateToolbarItemsWithSortButton:[self.controller supportSorting]] animated:YES];
         
-    }
-    else {
+    } else {
         _progressView.progressBar.progress = 0.;
         [self setToolbarItems:@[[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil], _progressBarButtonItem, [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]] animated:YES];
     }
@@ -224,11 +225,12 @@
 
 - (void)goBack
 {
-    if (((![self.currentPath isEqualToString:@""] && ![self.currentPath isEqualToString:@"/"]) && [self.currentPath length] > 0) && [self.controller isAuthorized]){
+    if (((![self.currentPath isEqualToString:@""] && ![self.currentPath isEqualToString:@"/"]) && [self.currentPath length] > 0) && [self.controller isAuthorized]) {
         self.currentPath = [self.currentPath stringByDeletingLastPathComponent];
         [self requestInformationForCurrentPath];
-    } else
+    } else {
         [self.navigationController popViewControllerAnimated:YES];
+    }
 }
 
 - (void)showLoginPanel
@@ -250,7 +252,6 @@
         //Only show sorting button and number of files button when there is no progress bar in the toolbar
         //Only show sorting button when controller support sorting and is authorized
         [self setToolbarItems:[self _generateToolbarItemsWithSortButton:self.controller.isAuthorized && [self.controller supportSorting]] animated:YES];
-       
     }
     if (self.controller.canPlayAll) {
         self.navigationItem.rightBarButtonItems = @[_logoutButton, [UIBarButtonItem themedPlayAllButtonWithTarget:self andSelector:@selector(playAllAction:)]];
@@ -274,8 +275,9 @@
     if (self.currentPath == nil) {
         self.currentPath = @"";
     }
-    if ([self.controller.currentListFiles count] == 0)
+    if ([self.controller.currentListFiles count] == 0) {
         [self requestInformationForCurrentPath];
+    }
 }
 
 - (void)logout
@@ -285,7 +287,7 @@
     [self updateViewAfterSessionChange];
 }
 
-- (void)sortButtonClicked:(UIBarButtonItem*)sender
+- (void)sortButtonClicked:(UIBarButtonItem *)sender
 {
     [self presentViewController:self->sheet animated:YES completion:^{
         [self->sheet.collectionView selectItemAtIndexPath:self->manager.selectedIndex animated:NO scrollPosition:UICollectionViewScrollPositionCenteredVertically];

--- a/Sources/VLCCloudStorageTableViewController.m
+++ b/Sources/VLCCloudStorageTableViewController.m
@@ -58,7 +58,7 @@
 
     self.tableView.rowHeight = [VLCCloudStorageTableViewCell heightOfCell];
 
-    _numberOfFilesBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"NUM_OF_FILES", nil), 0] style:UIBarButtonItemStylePlain target:nil action:nil];
+    _numberOfFilesBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
     _sortBarButtonItem = [[UIBarButtonItem alloc] initWithTitle: [NSString stringWithFormat:NSLocalizedString(@"SORT", nil), 0]
                                                           style:UIBarButtonItemStylePlain target:self action:@selector(sortButtonClicked:)];
     _sortBarButtonItem.tintColor = PresentationTheme.current.colors.orangeUI;
@@ -86,6 +86,7 @@
     [sheet.collectionView registerClass:[VLCActionSheetCell class] forCellWithReuseIdentifier:VLCActionSheetCell.identifier];
 
     [self _showProgressInToolbar:NO];
+    [self mediaListReset];
     [self updateForTheme];
 }
 
@@ -155,6 +156,10 @@
         self.numberOfFilesBarButtonItem.title = [NSString stringWithFormat:NSLocalizedString(@"NUM_OF_FILES", nil), count];
     else
         self.numberOfFilesBarButtonItem.title = NSLocalizedString(@"ONE_FILE", nil);
+
+- (void)mediaListReset
+{
+    self.numberOfFilesBarButtonItem.title = [NSString stringWithFormat:NSLocalizedString(@"NUM_OF_FILES", nil), 0];
 }
 
 - (NSArray*)_generateToolbarItemsWithSortButton : (BOOL)withsb

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -59,8 +59,9 @@
 {
     /* share our credentials */
     NSArray *credentials = [DBSDKKeychain retrieveAllTokenIds];
-    if (credentials == nil)
+    if (credentials == nil) {
         return;
+    }
 
     NSUbiquitousKeyValueStore *ubiquitousStore = [NSUbiquitousKeyValueStore defaultStore];
     [ubiquitousStore setArray:credentials forKey:kVLCStoreDropboxCredentials];
@@ -90,8 +91,9 @@
 {
     [DBClientsManager unlinkAndResetClients];
     [self reset];
-    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
+    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
+    }
     if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
         [self.delegate mediaListReset];
     }
@@ -193,8 +195,8 @@
     [[[self client].filesRoutes listFolder:path] setResponseBlock:^(DBFILESListFolderResult * _Nullable result, DBFILESListFolderError * _Nullable routeError, DBRequestError * _Nullable networkError) {
         if (result) {
             self.currentFileList = [result.entries sortedArrayUsingComparator:^NSComparisonResult(id a, id b) {
-                NSString *first = [(DBFILESMetadata*)a name];
-                NSString *second = [(DBFILESMetadata*)b name];
+                NSString *first = [(DBFILESMetadata *)a name];
+                NSString *second = [(DBFILESMetadata *)b name];
                 return [first caseInsensitiveCompare:second];
             }];
             APLog(@"found filtered metadata for %lu files", (unsigned long)self.currentFileList.count);

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -94,9 +94,6 @@
     if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
     }
-    if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
-        [self.delegate mediaListReset];
-    }
 }
 
 - (BOOL)isAuthorized

--- a/Sources/VLCDropboxController.m
+++ b/Sources/VLCDropboxController.m
@@ -92,6 +92,9 @@
     [self reset];
     if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
         [self.delegate mediaListUpdated];
+    if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
+        [self.delegate mediaListReset];
+    }
 }
 
 - (BOOL)isAuthorized

--- a/Sources/VLCDropboxTableViewController.m
+++ b/Sources/VLCDropboxTableViewController.m
@@ -123,9 +123,9 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     _selectedFile = _mediaList[indexPath.row];
-    if (![_selectedFile isKindOfClass:[DBFILESFolderMetadata class]])
+    if (![_selectedFile isKindOfClass:[DBFILESFolderMetadata class]]) {
         [_dropboxController streamFile:_selectedFile currentNavigationController:self.navigationController];
-    else {
+    } else {
         /* dive into subdirectory */
         NSString *futurePath = [self.currentPath stringByAppendingFormat:@"/%@", _selectedFile.name];
         self.currentPath = futurePath;
@@ -148,8 +148,9 @@
                                           openURL:^(NSURL *url) {
                                               [[UIApplication sharedApplication] openURL:url];
                                           }];
-    } else
+    } else {
         [_dropboxController logout];
+    }
 }
 
 - (void)sessionWasUpdated:(NSNotification *)aNotification

--- a/Sources/VLCEmptyLibraryView.h
+++ b/Sources/VLCEmptyLibraryView.h
@@ -19,7 +19,7 @@ typedef NS_ENUM (NSUInteger, VLCEmptyLibraryViewContentType)
     VLCEmptyLibraryViewContentTypePlaylist
 };
 
-@interface VLCEmptyLibraryView: UIView
+@interface VLCEmptyLibraryView : UIView
 
 @property (nonatomic, strong) IBOutlet UILabel *emptyLibraryLabel;
 @property (nonatomic, strong) IBOutlet UILabel *emptyLibraryLongDescriptionLabel;

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -80,8 +80,9 @@
     [ubiquitousStore setString:nil forKey:kVLCStoreGDriveCredentials];
     [ubiquitousStore synchronize];
     [self stopSession];
-    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
+    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
+    }
     if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
         [self.delegate mediaListReset];
     }
@@ -106,8 +107,9 @@
     /* share our credentials */
     XKKeychainGenericPasswordItem *item = [XKKeychainGenericPasswordItem itemForService:kKeychainItemName account:@"OAuth" error:nil]; // kGTMOAuth2AccountName
     NSString *credentials = item.secret.stringValue;
-    if (credentials == nil)
+    if (credentials == nil) {
         return;
+    }
 
     NSUbiquitousKeyValueStore *ubiquitousStore = [NSUbiquitousKeyValueStore defaultStore];
     [ubiquitousStore setString:credentials forKey:kVLCStoreGDriveCredentials];
@@ -119,8 +121,9 @@
     NSUbiquitousKeyValueStore *ubiquitousStore = [NSUbiquitousKeyValueStore defaultStore];
     [ubiquitousStore synchronize];
     NSString *credentials = [ubiquitousStore stringForKey:kVLCStoreGDriveCredentials];
-    if (!credentials)
+    if (!credentials) {
         return NO;
+    }
 
     XKKeychainGenericPasswordItem *keychainItem = [[XKKeychainGenericPasswordItem alloc] init];
     keychainItem.service = kKeychainItemName;
@@ -154,8 +157,9 @@
 {
     if (self.isAuthorized) {
         //we entered a different folder so discard all current files
-        if (![path isEqualToString:_folderId])
+        if (![path isEqualToString:_folderId]) {
             _currentFileList = nil;
+        }
         [self listFilesWithID:path];
     }
 }
@@ -167,18 +171,23 @@
 
 - (void)downloadFileToDocumentFolder:(GTLRDrive_File *)file
 {
-    if (file == nil)
+    if (file == nil) {
         return;
+    }
 
-    if ([file.mimeType isEqualToString:@"application/vnd.google-apps.folder"]) return;
+    if ([file.mimeType isEqualToString:@"application/vnd.google-apps.folder"]) {
+        return;
+    }
 
-    if (!_listOfGoogleDriveFilesToDownload)
+    if (!_listOfGoogleDriveFilesToDownload) {
         _listOfGoogleDriveFilesToDownload = [[NSMutableArray alloc] init];
+    }
 
     [_listOfGoogleDriveFilesToDownload addObject:file];
 
-    if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)])
+    if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)]) {
         [self.delegate numberOfFilesWaitingToBeDownloadedChanged];
+    }
 
     [self _triggerNextDownload];
 }
@@ -197,10 +206,11 @@
     query.fields = @"files(*)";
     
     //Set orderBy parameter based on sortBy
-    if (self.sortBy == VLCCloudSortingCriteriaName)
+    if (self.sortBy == VLCCloudSortingCriteriaName) {
         query.orderBy = @"folder,name,modifiedTime desc";
-    else
+    } else {
         query.orderBy = @"modifiedTime desc,folder,name";
+    }
 
     if (![_folderId isEqualToString:@""]) {
         parentName = [_folderId lastPathComponent];
@@ -241,8 +251,9 @@
         [self _reallyDownloadFileToDocumentFolder:_listOfGoogleDriveFilesToDownload[0]];
         [_listOfGoogleDriveFilesToDownload removeObjectAtIndex:0];
 
-        if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)])
+        if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)]) {
             [self.delegate numberOfFilesWaitingToBeDownloadedChanged];
+        }
     }
 }
 
@@ -253,16 +264,18 @@
 
     [self loadFile:file intoPath:filePath];
 
-    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStarted)])
+    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStarted)]) {
         [self.delegate operationWithProgressInformationStarted];
+    }
 
     _downloadInProgress = YES;
 }
 
 - (BOOL)_supportedFileExtension:(NSString *)filename
 {
-    if ([filename isSupportedMediaFormat] || [filename isSupportedAudioMediaFormat] || [filename isSupportedSubtitleFormat])
+    if ([filename isSupportedMediaFormat] || [filename isSupportedAudioMediaFormat] || [filename isSupportedSubtitleFormat]) {
         return YES;
+    }
 
     return NO;
 }
@@ -279,8 +292,9 @@
         BOOL isDirectory = [iter.mimeType isEqualToString:@"application/vnd.google-apps.folder"];
         BOOL supportedFile = [self _supportedFileExtension:iter.name];
 
-        if (isDirectory || supportedFile)
+        if (isDirectory || supportedFile) {
             [listOfGoodFilesAndFolders addObject:iter];
+        }
     }
     _currentFileList = [NSArray arrayWithArray:listOfGoodFilesAndFolders];
 
@@ -291,11 +305,12 @@
 
     APLog(@"found filtered metadata for %lu files", (unsigned long)_currentFileList.count);
 
-    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
+    if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
+    }
 }
 
-- (void)loadFile:(GTLRDrive_File*)file intoPath:(NSString*)destinationPath
+- (void)loadFile:(GTLRDrive_File *)file intoPath:(NSString *)destinationPath
 {
     NSString *exportURLStr =  [NSString stringWithFormat:@"https://www.googleapis.com/drive/v3/files/%@?alt=media",
                            file.identifier];
@@ -318,8 +333,9 @@
             }
 
             CGFloat progress = (CGFloat)totalBytesWritten / (CGFloat)[file.size unsignedLongValue];
-            if ([self.delegate respondsToSelector:@selector(currentProgressInformation:)])
+            if ([self.delegate respondsToSelector:@selector(currentProgressInformation:)]) {
                 [self.delegate currentProgressInformation:progress];
+            }
         };
 
         [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
@@ -349,8 +365,9 @@
     [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
 
     NSString  *remainingTime = [formatter stringFromDate:date];
-    if ([self.delegate respondsToSelector:@selector(updateRemainingTime:)])
+    if ([self.delegate respondsToSelector:@selector(updateRemainingTime:)]) {
         [self.delegate updateRemainingTime:remainingTime];
+    }
 }
 
 - (void)downloadSuccessful
@@ -364,18 +381,20 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.VLCNewFileAddedNotification
                                                         object:self];
 #endif
-    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)])
+    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)]) {
         [self.delegate operationWithProgressInformationStopped];
+    }
     _downloadInProgress = NO;
 
     [self _triggerNextDownload];
 }
 
-- (void)downloadFailedWithError:(NSError*)error
+- (void)downloadFailedWithError:(NSError *)error
 {
     APLog(@"DriveFile download failed with error %li", (long)error.code);
-    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)])
+    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)]) {
         [self.delegate operationWithProgressInformationStopped];
+    }
     _downloadInProgress = NO;
 
     [self _triggerNextDownload];
@@ -390,9 +409,9 @@
 
 - (NSInteger)numberOfFilesWaitingToBeDownloaded
 {
-    if (_listOfGoogleDriveFilesToDownload)
+    if (_listOfGoogleDriveFilesToDownload) {
         return _listOfGoogleDriveFilesToDownload.count;
-
+    }
     return 0;
 }
 

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -83,9 +83,6 @@
     if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
         [self.delegate mediaListUpdated];
     }
-    if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
-        [self.delegate mediaListReset];
-    }
 }
 
 - (BOOL)isAuthorized

--- a/Sources/VLCGoogleDriveController.m
+++ b/Sources/VLCGoogleDriveController.m
@@ -82,6 +82,9 @@
     [self stopSession];
     if ([self.delegate respondsToSelector:@selector(mediaListUpdated)])
         [self.delegate mediaListUpdated];
+    if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
+        [self.delegate mediaListReset];
+    }
 }
 
 - (BOOL)isAuthorized

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -248,9 +248,11 @@ static NSMutableDictionary *authentifiedHosts;
     return [[HTTPDataResponse alloc] initWithData:[@"\"OK\"" dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
-- (BOOL)fileIsInDocumentFolder:(NSString*)filepath
+- (BOOL)fileIsInDocumentFolder:(NSString *)filepath
 {
-    if (!filepath) return NO;
+    if (!filepath) {
+        return NO;
+    }
 
     NSError *error;
 
@@ -284,14 +286,20 @@ static NSMutableDictionary *authentifiedHosts;
 {
     NSString *filePath = [[path stringByReplacingOccurrencesOfString:@"/Thumbnail/" withString:@""] stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet];
 
-    if ([filePath isEqualToString:@"/"]) return [[HTTPErrorResponse alloc] initWithErrorCode:404];
+    if ([filePath isEqualToString:@"/"]) {
+        return [[HTTPErrorResponse alloc] initWithErrorCode:404];
+    }
 
     UIImage *thumbnail = [UIImage imageWithContentsOfFile:filePath];
-    if (!thumbnail) return [[HTTPErrorResponse alloc] initWithErrorCode:404];
+    if (!thumbnail) {
+        return [[HTTPErrorResponse alloc] initWithErrorCode:404];
+    }
 
     NSData *theData = UIImageJPEGRepresentation(thumbnail, .9);
 
-    if (!theData) return [[HTTPErrorResponse alloc] initWithErrorCode:404];
+    if (!theData) {
+        return [[HTTPErrorResponse alloc] initWithErrorCode:404];
+    }
 
     HTTPDataResponse *dataResponse = [[HTTPDataResponse alloc] initWithData:theData];
     dataResponse.contentType = @"image/jpg";
@@ -768,7 +776,7 @@ static NSMutableDictionary *authentifiedHosts;
 #pragma mark multipart form data parser delegate
 
 
-- (void)processStartOfPartWithHeader:(MultipartMessageHeader*) header
+- (void)processStartOfPartWithHeader:(MultipartMessageHeader *) header
 {
     /* in this sample, we are not interested in parts, other then file parts.
      * check content disposition to find out filename */
@@ -841,7 +849,7 @@ static NSMutableDictionary *authentifiedHosts;
 #endif
 }
 
-- (void)processContent:(NSData*)data WithHeader:(MultipartMessageHeader*) header
+- (void)processContent:(NSData *)data WithHeader:(MultipartMessageHeader *) header
 {
     // here we just write the output from parser to the file.
     if (_storeFile) {
@@ -862,7 +870,7 @@ static NSMutableDictionary *authentifiedHosts;
 
 }
 
-- (void)processEndOfPartWithHeader:(MultipartMessageHeader*)header
+- (void)processEndOfPartWithHeader:(MultipartMessageHeader *)header
 {
     // as the file part is over, we close the file.
     APLog(@"closing file");

--- a/Sources/VLCHTTPConnection.m
+++ b/Sources/VLCHTTPConnection.m
@@ -776,7 +776,7 @@ static NSMutableDictionary *authentifiedHosts;
 #pragma mark multipart form data parser delegate
 
 
-- (void)processStartOfPartWithHeader:(MultipartMessageHeader *) header
+- (void)processStartOfPartWithHeader:(MultipartMessageHeader *)header
 {
     /* in this sample, we are not interested in parts, other then file parts.
      * check content disposition to find out filename */
@@ -849,7 +849,7 @@ static NSMutableDictionary *authentifiedHosts;
 #endif
 }
 
-- (void)processContent:(NSData *)data WithHeader:(MultipartMessageHeader *) header
+- (void)processContent:(NSData *)data WithHeader:(MultipartMessageHeader *)header
 {
     // here we just write the output from parser to the file.
     if (_storeFile) {

--- a/Sources/VLCMediaFileDiscoverer.m
+++ b/Sources/VLCMediaFileDiscoverer.m
@@ -223,11 +223,11 @@ const float MediaTimerInterval = 2.f;
     _directoryFiles = foundFiles;
 }
 
-- (void)didAddMedia:(NSTimer*)timer
+- (void)didAddMedia:(NSTimer *)timer
 {
 #if TARGET_OS_IOS
     BOOL hideMediaLibrary = [NSUserDefaults.standardUserDefaults boolForKey:kVLCSettingHideLibraryInFilesApp];
-    [(NSURL*)[timer.userInfo valueForKey:@"fileURL"] setHidden:hideMediaLibrary recursive:NO onlyFirstLevel:NO :nil];
+    [(NSURL *)[timer.userInfo valueForKey:@"fileURL"] setHidden:hideMediaLibrary recursive:NO onlyFirstLevel:NO :nil];
 #endif
     [NSFileManager.defaultManager removeItemAtPath:[NSString pathWithComponents:@[_directoryPath, NSLocalizedString(@"MEDIALIBRARY_ADDING_PLACEHOLDER", "")]] error:nil];
 }

--- a/Sources/VLCOneDriveController.h
+++ b/Sources/VLCOneDriveController.h
@@ -26,7 +26,7 @@
 
 + (VLCOneDriveController *)sharedInstance;
 
-- (void)loginWithViewController:(UIViewController*)presentingViewController;
+- (void)loginWithViewController:(UIViewController *)presentingViewController;
 
 - (void)startDownloadingODItem:(ODItem *)item;
 

--- a/Sources/VLCOneDriveController.m
+++ b/Sources/VLCOneDriveController.m
@@ -105,6 +105,12 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         self->_rootItemID = nil;
         self->_parentItem = nil;
         dispatch_async(dispatch_get_main_queue(), ^{
+            if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
+                [self.delegate mediaListUpdated];
+            }
+            if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
+                [self.delegate mediaListReset];
+            }
             if (self->_presentingViewController) {
                 [self->_presentingViewController.navigationController popViewControllerAnimated:YES];
             }

--- a/Sources/VLCOneDriveController.m
+++ b/Sources/VLCOneDriveController.m
@@ -108,9 +108,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
             if ([self.delegate respondsToSelector:@selector(mediaListUpdated)]) {
                 [self.delegate mediaListUpdated];
             }
-            if ([self.delegate respondsToSelector:@selector(mediaListReset)]) {
-                [self.delegate mediaListReset];
-            }
             if (self->_presentingViewController) {
                 [self->_presentingViewController.navigationController popViewControllerAnimated:YES];
             }

--- a/Sources/VLCOneDriveController.m
+++ b/Sources/VLCOneDriveController.m
@@ -142,8 +142,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     APLog(@"VLCOneDriveController: Authentication failure.");
 
     if (self.delegate) {
-        if ([self.delegate respondsToSelector:@selector(sessionWasUpdated)])
+        if ([self.delegate respondsToSelector:@selector(sessionWasUpdated)]) {
             [self.delegate performSelector:@selector(sessionWasUpdated)];
+        }
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:VLCOneDriveControllerSessionUpdated object:self];
 }
@@ -335,13 +336,16 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)startDownloadingODItem:(ODItem *)item
 {
-    if (item == nil)
+    if (item == nil) {
         return;
-    if (item.folder)
+    }
+    if (item.folder) {
         return;
+    }
 
-    if (!_pendingDownloads)
+    if (!_pendingDownloads) {
         _pendingDownloads = [[NSMutableArray alloc] init];
+    }
     [_pendingDownloads addObject:item];
 
     [self _triggerNextDownload];
@@ -383,24 +387,27 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         [self downloadODItem:_pendingDownloads.firstObject];
         [_pendingDownloads removeObjectAtIndex:0];
 
-        if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)])
+        if ([self.delegate respondsToSelector:@selector(numberOfFilesWaitingToBeDownloadedChanged)]) {
             [self.delegate numberOfFilesWaitingToBeDownloadedChanged];
+        }
     }
 }
 
 - (void)downloadStarted
 {
     _startDL = [NSDate timeIntervalSinceReferenceDate];
-    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStarted)])
+    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStarted)]) {
         [self.delegate operationWithProgressInformationStarted];
+    }
 }
 
 - (void)downloadEnded
 {
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString(@"GDRIVE_DOWNLOAD_SUCCESSFUL", nil));
 
-    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)])
+    if ([self.delegate respondsToSelector:@selector(operationWithProgressInformationStopped)]) {
         [self.delegate operationWithProgressInformationStopped];
+    }
 
 #if TARGET_OS_IOS
     // FIXME: Replace notifications by cleaner observers
@@ -439,8 +446,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)progressUpdated:(CGFloat)progress
 {
-    if ([self.delegate respondsToSelector:@selector(currentProgressInformation:)])
+    if ([self.delegate respondsToSelector:@selector(currentProgressInformation:)]) {
         [self.delegate currentProgressInformation:progress];
+    }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
@@ -469,8 +477,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
 
     NSString  *remaingTime = [formatter stringFromDate:date];
-    if ([self.delegate respondsToSelector:@selector(updateRemainingTime:)])
+    if ([self.delegate respondsToSelector:@selector(updateRemainingTime:)]) {
         [self.delegate updateRemainingTime:remaingTime];
+    }
 }
 
 @end

--- a/Sources/VLCPlaybackService.m
+++ b/Sources/VLCPlaybackService.m
@@ -1142,7 +1142,7 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
     [self setNeedsMetadataUpdate];
 }
 
-- (void)mediaMetaDataDidChange:(VLCMedia*)aMedia
+- (void)mediaMetaDataDidChange:(VLCMedia *)aMedia
 {
     [self setNeedsMetadataUpdate];
 }
@@ -1168,7 +1168,9 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
 - (void)_recoverLastPlaybackState
 {
     VLCMLMedia *media = [_delegate mediaForPlayingMedia:_mediaPlayer.media];
-    if (!media) return;
+    if (!media) {
+        return;
+    }
 
     CGFloat lastPosition = media.progress;
     // .95 prevents the controller from opening and closing immediatly when restoring state

--- a/Sources/VLCPlayerDisplayController.m
+++ b/Sources/VLCPlayerDisplayController.m
@@ -26,7 +26,7 @@ static NSString *const VLCPlayerDisplayControllerDisplayModeKey = @"VLCPlayerDis
 NSString *const VLCPlayerDisplayControllerDisplayMiniPlayer = @"VLCPlayerDisplayControllerDisplayMiniPlayer";
 NSString *const VLCPlayerDisplayControllerHideMiniPlayer = @"VLCPlayerDisplayControllerHideMiniPlayer";
 
-@interface VLCUntouchableView: UIView
+@interface VLCUntouchableView : UIView
 @end
 
 @implementation VLCUntouchableView


### PR DESCRIPTION
<!-- Thanks for contributing to _vlc-ios_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->

https://code.videolan.org/videolan/vlc-ios/-/issues/921

Fix number of files after OneDrive logout + reset it to default after all cloud services logout.

BONUS: fix spacings and add many missed brackets
