### PR TITLE
Fix shuffle behaviour

### DIFF
--- a/Sources/VLCPlaybackService.m
+++ b/Sources/VLCPlaybackService.m
@@ -1458,8 +1458,3 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
 }
 
 @end
-
-
-
-
-


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec fastlane test` from the `fastlane` directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
Shuffling is now done when the shuffle button is pressed, making an array of unique positions in the playlist. Behaviour now matches other music apps.
