### PR TITLE
Add manage app config (for MDM) for videos and streams

### DIFF
--- a/Apple-TV/AppleTVAppDelegate.m
+++ b/Apple-TV/AppleTVAppDelegate.m
@@ -14,6 +14,7 @@
 #import "AppleTVAppDelegate.h"
 #import "VLCServerListTVViewController.h"
 #import "VLCOpenNetworkStreamTVViewController.h"
+#import "VLCOpenManagedServersViewController.h"
 #import "VLCSettingsViewController.h"
 #import "VLCCloudServicesTVViewController.h"
 #import "VLCHTTPUploaderController.h"
@@ -28,6 +29,7 @@
     VLCCloudServicesTVViewController *_cloudServicesVC;
     VLCRemotePlaybackViewController *_remotePlaybackVC;
     VLCOpenNetworkStreamTVViewController *_openNetworkVC;
+    VLCOpenManagedServersViewController *_openManagedServersVC;
     VLCSettingsViewController *_settingsVC;
 }
 
@@ -70,15 +72,26 @@
     _localNetworkVC = [[VLCServerListTVViewController alloc] initWithNibName:nil bundle:nil];
     _remotePlaybackVC = [[VLCRemotePlaybackViewController alloc] initWithNibName:nil bundle:nil];
     _openNetworkVC = [[VLCOpenNetworkStreamTVViewController alloc] initWithNibName:nil bundle:nil];
+    _openManagedServersVC = [[VLCOpenManagedServersViewController alloc] initWithNibName:nil bundle:nil];
     _settingsVC = [[VLCSettingsViewController alloc] initWithNibName:nil bundle:nil];
 
     _mainViewController = [[UITabBarController alloc] init];
     _mainViewController.tabBar.barTintColor = [UIColor VLCOrangeTintColor];
+    
+    UINavigationController *_managedServers = [[UINavigationController alloc] initWithRootViewController:_openManagedServersVC];
+    
+    NSMutableArray *_viewControllers = [[NSMutableArray alloc]initWithArray:@[
+        [[UINavigationController alloc] initWithRootViewController:_localNetworkVC],
+        [[UINavigationController alloc] initWithRootViewController:_remotePlaybackVC],
+        [[UINavigationController alloc] initWithRootViewController:_openNetworkVC]
+    ]];
 
-    _mainViewController.viewControllers = @[[[UINavigationController alloc] initWithRootViewController:_localNetworkVC],
-                                            [[UINavigationController alloc] initWithRootViewController:_remotePlaybackVC],
-                                            [[UINavigationController alloc] initWithRootViewController:_openNetworkVC],
-                                            [[UINavigationController alloc] initWithRootViewController:_settingsVC]];
+    if(_openManagedServersVC.hasManagedServers) {
+        [_viewControllers addObject:_managedServers];
+    }
+    [_viewControllers addObject:[[UINavigationController alloc] initWithRootViewController:_settingsVC]];
+    
+    [_mainViewController setViewControllers:_viewControllers];
 
     self.window.rootViewController = _mainViewController;
 

--- a/Apple-TV/VLCOpenManagedServersViewController.h
+++ b/Apple-TV/VLCOpenManagedServersViewController.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+ * VLC for iOS
+ *****************************************************************************
+ * Copyright (c) 2015 VideoLAN. All rights reserved.
+ * $Id$
+ *
+ * Authors: Felix Paul Kühne <fkuehne # videolan.org>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
+
+#import <UIKit/UIKit.h>
+#import "VLCDeletionCapableViewController.h"
+
+@interface VLCOpenManagedServersViewController : VLCDeletionCapableViewController <UITableViewDataSource, UITableViewDelegate>
+
+@property (readwrite, nonatomic, weak) IBOutlet UITableView *managedServersTableView;
+
+@property (readonly, nonatomic) BOOL hasManagedServers;
+
+@end

--- a/Apple-TV/VLCOpenManagedServersViewController.m
+++ b/Apple-TV/VLCOpenManagedServersViewController.m
@@ -1,0 +1,146 @@
+/*****************************************************************************
+ * VLC for iOS
+ *****************************************************************************
+ * Copyright (c) 2015 VideoLAN. All rights reserved.
+ * $Id$
+ *
+ * Authors: Felix Paul Kühne <fkuehne # videolan.org>
+ *
+ * Refer to the COPYING file of the official project for license.
+ *****************************************************************************/
+
+#import "VLCOpenManagedServersViewController.h"
+#import "VLCPlaybackService.h"
+#import "VLCPlayerDisplayController.h"
+#import "VLCFullscreenMovieTVViewController.h"
+#import "CAAnimation+VLCWiggle.h"
+
+@interface VLCOpenManagedServersViewController ()
+{
+    NSMutableArray *_serverList;
+    NSDictionary *_managedConf;
+}
+@property (nonatomic) NSIndexPath *currentlyFocusedIndexPath;
+@property (nonatomic) NSMutableArray *serverList;
+@end
+
+@implementation VLCOpenManagedServersViewController
+
+- (NSString *)title
+{
+    return NSLocalizedString(@"MANAGED_SERVERS", nil);
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+    NSDictionary *_managedConf = [NSUserDefaults.standardUserDefaults dictionaryForKey:@"com.apple.configuration.managed"];
+    
+    if (_managedConf == nil) {
+        _managedConf = @{};
+    }
+    
+    _serverList = [_managedConf mutableArrayValueForKey:@"server-list"];
+
+    return [super initWithNibName:@"VLCOpenManagedServersViewController" bundle:nil];
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    if (@available(tvOS 13.0, *)) {
+        self.navigationController.navigationBarHidden = YES;
+    }
+
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    [notificationCenter addObserver:self
+                           selector:@selector(ubiquitousKeyValueStoreDidChange:)
+                               name:NSUbiquitousKeyValueStoreDidChangeExternallyNotification
+                             object:[NSUbiquitousKeyValueStore defaultStore]];
+
+    self.managedServersTableView.backgroundColor = [UIColor clearColor];
+    self.managedServersTableView.rowHeight = UITableViewAutomaticDimension;
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [self.managedServersTableView reloadData];
+    [super viewWillAppear:animated];
+}
+
+- (void)ubiquitousKeyValueStoreDidChange:(NSNotification *)notification
+{
+    if (![NSThread isMainThread]) {
+        [self performSelectorOnMainThread:@selector(ubiquitousKeyValueStoreDidChange:) withObject:notification waitUntilDone:NO];
+        return;
+    }
+
+    [self.managedServersTableView reloadData];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+
+    /* force update before we leave */
+    [[NSUbiquitousKeyValueStore defaultStore] synchronize];
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"RecentlyPlayedURLsTableViewCell"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"RecentlyPlayedURLsTableViewCell"];
+    }
+    
+    NSString *content = [_serverList[indexPath.row] objectForKey:@"url"];
+    NSString *possibleTitle = [_serverList[indexPath.row] objectForKey:@"name"];
+
+    cell.detailTextLabel.text = content;
+    cell.textLabel.text = (possibleTitle != nil) ? possibleTitle : [content lastPathComponent];
+
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *_url = [_serverList[indexPath.row] objectForKey:@"url"];
+    
+    [self.managedServersTableView deselectRowAtIndexPath:indexPath animated:NO];
+    [self _openURLStringAndDismiss:_url];
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    NSInteger count = _serverList.count;
+    return count;
+}
+
+- (void)tableView:(UITableView *)tableView didHighlightRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    self.currentlyFocusedIndexPath = indexPath;
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    return 1;
+}
+
+- (void)_openURLStringAndDismiss:(NSString *)urlString
+{
+    VLCPlaybackService *vpc = [VLCPlaybackService sharedInstance];
+    VLCMedia *media = [VLCMedia mediaWithURL:[NSURL URLWithString:urlString]];
+    VLCMediaList *medialist = [[VLCMediaList alloc] init];
+    [medialist addMedia:media];
+
+    [vpc playMediaList:medialist firstIndex:0 subtitlesFilePath:nil];
+    [self presentViewController:[VLCFullscreenMovieTVViewController fullscreenMovieTVViewController]
+                       animated:YES
+                     completion:nil];
+}
+
+- (BOOL)hasManagedServers {
+    NSInteger count = _serverList.count;
+    if (count > 0) return YES;
+    else return NO;
+}
+
+@end

--- a/Apple-TV/VLCOpenManagedServersViewController.xib
+++ b/Apple-TV/VLCOpenManagedServersViewController.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.XIB" version="3.0" toolsVersion="20037" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="appleTV" appearance="light"/>
+    <dependencies>
+        <deployment identifier="tvOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VLCOpenManagedServersViewController">
+            <connections>
+                <outlet property="managedServersTableView" destination="v0o-s0-Xaz" id="y2g-wA-YdX"/>
+                <outlet property="view" destination="iN0-l3-epB" id="Eym-vH-oyN"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" ambiguous="YES" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="66" sectionHeaderHeight="40" sectionFooterHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="v0o-s0-Xaz">
+                    <rect key="frame" x="182.5" y="193" width="1555" height="791"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="791" id="IB0-z1-Abd"/>
+                        <constraint firstAttribute="width" constant="1555" id="LYi-d6-NCG"/>
+                    </constraints>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="5xO-BE-h5Q"/>
+                        <outlet property="delegate" destination="-1" id="osW-Kv-1VK"/>
+                    </connections>
+                </tableView>
+            </subviews>
+            <constraints>
+                <constraint firstItem="v0o-s0-Xaz" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Rc3-GK-Hcy"/>
+                <constraint firstAttribute="bottom" secondItem="v0o-s0-Xaz" secondAttribute="bottom" constant="70" id="b6M-nT-Wk3"/>
+                <constraint firstItem="v0o-s0-Xaz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="193" id="kYM-aD-JmQ"/>
+            </constraints>
+            <point key="canvasLocation" x="185" y="34"/>
+        </view>
+    </objects>
+</document>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -86,6 +86,8 @@
 "SHARED_VLC_IOS_LIBRARY" = "Shared VLC for iOS Library";
 "SMB_CIFS_FILE_SERVERS" = "File Servers (SMB)";
 
+"MANAGED_SERVERS" = "Managed";
+
 "SMB_CIFS_FILE_SERVERS_SHORT" = "SMB";
 
 

--- a/VLC.xcodeproj/project.pbxproj
+++ b/VLC.xcodeproj/project.pbxproj
@@ -333,6 +333,8 @@
 		9B9231C4185A703700F89498 /* VLCNetworkLoginViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9B9231C3185A703700F89498 /* VLCNetworkLoginViewController.xib */; };
 		9BADAF45185FBD9D00108BD8 /* VLCFrostedGlasView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BADAF44185FBD9D00108BD8 /* VLCFrostedGlasView.m */; };
 		9BE4D1CE183D76950006346C /* VLCCloudStorageTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D3784B0183A990F009EE944 /* VLCCloudStorageTableViewCell.m */; };
+		A1CA2EF328240A8D000DB82F /* VLCOpenManagedServersViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A1CA2EF228240A8D000DB82F /* VLCOpenManagedServersViewController.xib */; };
+		A1CA2EF628240BA0000DB82F /* VLCOpenManagedServersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A1CA2EF528240BA0000DB82F /* VLCOpenManagedServersViewController.m */; };
 		A483C473E441E7BA7B31BF76 /* libPods-VLC-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6CC455148EC65B1D66CC66 /* libPods-VLC-iOS.a */; };
 		A79246C8170F11DF0036AAF2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A79246C6170F11DF0036AAF2 /* Localizable.strings */; };
 		CAA0B0ED2072651000B9274E /* VLCTestMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF76D8F20709C4100E2AD7B /* VLCTestMenu.swift */; };
@@ -954,6 +956,9 @@
 		9B9231C3185A703700F89498 /* VLCNetworkLoginViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = VLCNetworkLoginViewController.xib; path = Resources/VLCNetworkLoginViewController.xib; sourceTree = SOURCE_ROOT; };
 		9BADAF43185FBD9D00108BD8 /* VLCFrostedGlasView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VLCFrostedGlasView.h; path = Sources/VLCFrostedGlasView.h; sourceTree = SOURCE_ROOT; };
 		9BADAF44185FBD9D00108BD8 /* VLCFrostedGlasView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VLCFrostedGlasView.m; path = Sources/VLCFrostedGlasView.m; sourceTree = SOURCE_ROOT; };
+		A1CA2EF228240A8D000DB82F /* VLCOpenManagedServersViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VLCOpenManagedServersViewController.xib; sourceTree = "<group>"; };
+		A1CA2EF428240B8E000DB82F /* VLCOpenManagedServersViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VLCOpenManagedServersViewController.h; sourceTree = "<group>"; };
+		A1CA2EF528240BA0000DB82F /* VLCOpenManagedServersViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VLCOpenManagedServersViewController.m; sourceTree = "<group>"; };
 		A7035BBD174519600057DFA7 /* iTunesArtwork */ = {isa = PBXFileReference; lastKnownFileType = file; path = iTunesArtwork; sourceTree = "<group>"; };
 		A79246C7170F11DF0036AAF2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; lineEnding = 0; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.simpleColoring; };
 		A79246C9170F11E40036AAF2 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1844,6 +1849,7 @@
 				7DC0B56F1C0094370027BFAD /* VLCSettingsViewController.xib */,
 				2663ACB322497D47000FBB95 /* VLCNetworkLoginTVViewController.xib */,
 				7D21407E2431F3A40075E767 /* VLCPlaybackInfoSubtitlesFetcherViewController.xib */,
+				A1CA2EF228240A8D000DB82F /* VLCOpenManagedServersViewController.xib */,
 			);
 			name = xibs;
 			sourceTree = "<group>";
@@ -1912,6 +1918,8 @@
 				7DB174A51CD20D7B0085BCF0 /* VLCSearchableServerBrowsingTVViewController.h */,
 				7DB174A61CD20D7B0085BCF0 /* VLCSearchableServerBrowsingTVViewController.m */,
 				2663ACB122497D21000FBB95 /* VLCNetworkLoginTVViewController.swift */,
+				A1CA2EF428240B8E000DB82F /* VLCOpenManagedServersViewController.h */,
+				A1CA2EF528240BA0000DB82F /* VLCOpenManagedServersViewController.m */,
 			);
 			name = "Network UI";
 			sourceTree = "<group>";
@@ -2780,6 +2788,7 @@
 				7DEDD38C1BE936130053802C /* About Contents.html in Resources */,
 				7D5B26651D6350BF00FE7B4D /* gradient-cell.png in Resources */,
 				7DF383AE1BF206FB00D71A5C /* VLCRemoteBrowsingCollectionViewController.xib in Resources */,
+				A1CA2EF328240A8D000DB82F /* VLCOpenManagedServersViewController.xib in Resources */,
 				7D21407F2431F3A50075E767 /* VLCPlaybackInfoSubtitlesFetcherViewController.xib in Resources */,
 				7DDE41931BE925820065C53A /* Assets.xcassets in Resources */,
 				DD29A3E91BF223D000A27A91 /* Localizable.strings in Resources */,
@@ -3096,6 +3105,7 @@
 				7DDE418F1BE9225A0065C53A /* VLCAboutViewController.m in Sources */,
 				7D0C34E71BD951080058CD19 /* NSString+SupportedMedia.m in Sources */,
 				DD8095F61BE624C00065D8E1 /* VLCPlaybackInfoTVAnimators.m in Sources */,
+				A1CA2EF628240BA0000DB82F /* VLCOpenManagedServersViewController.m in Sources */,
 				DDEAECBF1BDEBF6700756C83 /* VLCNetworkServerLoginInformation.m in Sources */,
 				7D2DE69C24D5AC0E00E8D84D /* VLCOSOFetcher.m in Sources */,
 				DD3EFF381BDEBCE500B68579 /* VLCLocalNetworkServiceNetService.m in Sources */,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec fastlane test` from the `fastlane` directory to see all new and existing tests pass
- [x] I've followed the [vlc-ios code style](Docs/CodingStyle.md)
- [x] I've read the [Contribution Guidelines](https://github.com/videolan/vlc-ios#contribute)
- [x] I've updated the documentation if necessary.

### Description
This adds support for [Managed App Configuration](https://developer.apple.com/library/archive/samplecode/sc2279/Introduction/Intro.html) so that a list of video files/streams can be delivered via an MDM solution, such as Jamf. If the server-list key is sent, this will add a `Managed` tab that can reference video streams for the tvOS app.

Here's an example app configuration that could be used:

```
<dict>
		<key>server-list</key>
		<array>
                        <dict>
                               <key>name</key>
                               <string>Example 1</string>
                               <key>url</key>
                               <string>https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4</string>
                        </dict>
                        <dict>
                               <key>name</key>
                               <string>Example 2</string>
                               <key>url</key>
                               <string>https://sample-videos.com/video123/mp4/240/big_buck_bunny_240p_30mb.mp4</string>
                        </dict>
		</array>
</dict>
```

Our basic use case is to add non-public facing IP cams that we can then push to many different Apple TVs in our organization.

If this request is accepted, I will add a section to the tvOS section of the VLC documentation wiki.