### PR TITLE
ios: fix: last selected subtitle not recovered

### DIFF
--- a/Sources/Playback/Control/VLCPlaybackService.m
+++ b/Sources/Playback/Control/VLCPlaybackService.m
@@ -454,8 +454,12 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
     VLCMLMedia *media = [_delegate mediaForPlayingMedia:_mediaPlayer.media];
 
     if (media) {
-        _mediaPlayer.currentAudioTrackIndex = (int) media.audioTrackIndex;
-        _mediaPlayer.currentVideoSubTitleIndex = (int) media.subtitleTrackIndex;
+        NSTimeInterval delayInSeconds = 0.2;
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+        dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+            _mediaPlayer.currentAudioTrackIndex = (int) media.audioTrackIndex;
+            _mediaPlayer.currentVideoSubTitleIndex = 3; // (int) media.subtitleTrackIndex;
+        });
     }
 }
 #endif

--- a/Sources/Playback/Control/VLCPlaybackService.m
+++ b/Sources/Playback/Control/VLCPlaybackService.m
@@ -458,7 +458,7 @@ NSString *const VLCPlaybackServicePlaybackPositionUpdated = @"VLCPlaybackService
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
             _mediaPlayer.currentAudioTrackIndex = (int) media.audioTrackIndex;
-            _mediaPlayer.currentVideoSubTitleIndex = 3; // (int) media.subtitleTrackIndex;
+            _mediaPlayer.currentVideoSubTitleIndex = (int) media.subtitleTrackIndex;
         });
     }
 }


### PR DESCRIPTION
Add a small delay to recover the playback state.

The bug reproduce steps(install VLC on iPhone)：
1. Play a video with two or more subtitles,
2. Switch to a subtitle other than the first one
3. close the video and back to the video list
4. Open the same video again
5. The selected subtitle was the first one.

Expected behavior:
At step 5, the selected subtitle should be the one last selected.