### PR TITLE
Player: Swipe to minimize

### DIFF
--- a/Sources/Playback/Player/PlayerViewController.swift
+++ b/Sources/Playback/Player/PlayerViewController.swift
@@ -528,11 +528,15 @@ class PlayerViewController: UIViewController {
         let windowWidth: CGFloat = window.bounds.width
         let location: CGPoint = recognizer.location(in: window)
 
-        // Default or right side of the screen
-        var panType: PlayerPanType = .volume
-
-        if location.x < windowWidth / 2 {
-            panType = .brightness
+        var panType: PlayerPanType = .none
+        if location.x < 3 * windowWidth / 3 && playerController.isVolumeGestureEnabled {
+            panType = .volume
+        }
+        if location.x < 2 * windowWidth / 3 {
+            panType = .none
+        }
+        if location.x < 1 * windowWidth / 3 && playerController.isBrightnessGestureEnabled {
+             panType = .brightness
         }
 
         if playbackService.currentMediaIs360Video {
@@ -603,6 +607,9 @@ class PlayerViewController: UIViewController {
         let currentPos = recognizer.location(in: view)
 
         let panType = detectPanType(recognizer)
+        if panType == .none {
+            return handleMinimizeGesture(recognizer)
+        }
 
         guard panType == .projection
                 || (panType == .volume && playerController.isVolumeGestureEnabled)

--- a/Sources/Playback/Player/PlayerViewController.swift
+++ b/Sources/Playback/Player/PlayerViewController.swift
@@ -787,8 +787,8 @@ class PlayerViewController: UIViewController {
 
             break
         case .ended:
-            let halfHeight = view.frame.height / 2
-            if viewTranslation.y < halfHeight {
+            let height = view.frame.height * 0.1
+            if viewTranslation.y < height {
                 UIView.animate(withDuration: 0.5,
                                delay: 0,
                                usingSpringWithDamping: 0.7,

--- a/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
+++ b/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
@@ -973,11 +973,15 @@ extension VideoPlayerViewController {
         let windowWidth: CGFloat = window.bounds.width
         let location: CGPoint = recognizer.location(in: window)
 
-        // Default or right side of the screen
-        var panType: VideoPlayerPanType = .volume
-
-        if location.x < windowWidth / 2 {
-            panType = .brightness
+        var panType: VideoPlayerPanType = .none
+        if location.x < 3 * windowWidth / 3 && playerController.isVolumeGestureEnabled {
+            panType = .volume
+        }
+        if location.x < 2 * windowWidth / 3 {
+            panType = .none
+        }
+        if location.x < 1 * windowWidth / 3 && playerController.isBrightnessGestureEnabled {
+             panType = .brightness
         }
 
         if playbackService.currentMediaIs360Video {
@@ -1022,6 +1026,9 @@ extension VideoPlayerViewController {
             return
         }
         let panType = detectPanType(recognizer)
+        if panType == .none {
+            return handleMinimizeGesture(recognizer)
+        }
 
         guard panType == .projection
                 || (panType == .volume && playerController.isVolumeGestureEnabled)

--- a/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
+++ b/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
@@ -1201,8 +1201,8 @@ extension VideoPlayerViewController {
 
             break
         case .ended:
-            let halfHeight = view.frame.height / 2
-            if viewTranslation.y < halfHeight {
+            let height = view.frame.height * 0.1
+            if viewTranslation.y < height {
                 UIView.animate(withDuration: 0.5,
                                delay: 0,
                                usingSpringWithDamping: 0.7,


### PR DESCRIPTION
This patch adjusts the distance you have to swipe to minimize the
player from 50% of the view height to 10%, making it significantly
easier minimize the player.

This patch also makes it so that you can swipe down from the middle
of the screen to minimize the player. If the volume/brightness gestures
are disabled, you're able to swipe down from anywhere on the screen.

# Before

![before](https://github.com/videolan/vlc-ios/assets/40562373/281ab42b-7061-43f3-8549-e216c65c8ffb)

# After

![after](https://github.com/videolan/vlc-ios/assets/40562373/b8c0eb15-eb90-4922-863e-ab46a1fbeada)