### PR TITLE
BugFix: When shuffle is on, the first song in the album is always the first song played.

### DIFF
--- a/Sources/Playback/Control/VLCPlaybackService.m
+++ b/Sources/Playback/Control/VLCPlaybackService.m
@@ -349,11 +349,11 @@ NSString *const VLCPlaybackServicePlaybackDidMoveOnToNextItem = @"VLCPlaybackSer
     if (_itemInMediaListToBePlayedFirst == -1) {
         int count = (int)_mediaList.count;
         if (_shuffleMode && count > 0) {
-                _currentIndex = arc4random_uniform(count - 1);
-                [self shuffleMediaList];
+            _itemInMediaListToBePlayedFirst = arc4random_uniform(count - 1);
+            [self shuffleMediaList];
+        } else {
+            _itemInMediaListToBePlayedFirst = 0;
         }
-
-        _itemInMediaListToBePlayedFirst = 0;
     }
 
     VLCMedia *media = [_mediaList mediaAtIndex:_itemInMediaListToBePlayedFirst];


### PR DESCRIPTION
Ideally shuffle should start from a random song

Closes #1721