### PR TITLE
fix: enable supportedSubtitles pathway

### DIFF
--- a/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
+++ b/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
@@ -1739,7 +1739,7 @@ extension VideoPlayerViewController: UIDocumentPickerDelegate {
             }
             fileURL.stopAccessingSecurityScopedResource()
 
-            if fileURL.pathExtension.contains("srt") {
+            if fileURL.path.isSupportedSubtitleFormat() {
                 playbackService.addSubtitlesToCurrentPlayback(from: URL(fileURLWithPath: destinationPath))
             } else {
                 playbackService.addAudioToCurrentPlayback(from: URL(fileURLWithPath: destinationPath))


### PR DESCRIPTION
This PR updates the in-player Files subtitle picker to classify files using VLC’s existing supported subtitle extension list instead of only recognizing `.srt`. 

As a result, `.ass`, `.ssa`, and other already-supported subtitle formats are attached as subtitle tracks rather than being incorrectly routed as external audio.