### PR TITLE
VideoPlayerViewController: Fix frozen video on external display after backgrounding

### DIFF
--- a/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
+++ b/Sources/Playback/Player/VideoPlayer-iOS/VideoPlayerViewController.swift
@@ -1492,11 +1492,20 @@ extension VideoPlayerViewController: PlayerControllerDelegate {
     }
 
     func playerControllerApplicationBecameActive(_ playerController: PlayerController) {
-        if (delegate?.videoPlayerViewControllerShouldBeDisplayed(self)) != nil {
-            playbackService.recoverDisplayedMetadata()
-            if playbackService.videoOutputView != videoOutputView {
-                playbackService.videoOutputView = videoOutputView
-            }
+        guard delegate?.videoPlayerViewControllerShouldBeDisplayed(self) != nil else { return }
+
+        playbackService.recoverDisplayedMetadata()
+
+        if playbackService.isPlayingOnExternalScreen(),
+           playbackService.renderer == nil,
+           VLCAppCoordinator.sharedInstance().externalWindow != nil {
+            playbackService.videoOutputView = nil
+            playbackService.videoOutputView = videoOutputView
+            return
+        }
+
+        if playbackService.videoOutputView != videoOutputView {
+            playbackService.videoOutputView = videoOutputView
         }
     }
 }


### PR DESCRIPTION
### Summary
Playing video on a wired external display (USB-C/HDMI) freezes after the app
is sent to the background and brought back to the foreground: the picture
stays on the last frame on the external monitor while audio and the timeline
keep advancing. Only physically reconnecting the display restores the picture.

### Cause
The video output view that hosts the vout render surface lives inside the
external `UIWindow`. While the app is backgrounded, that surface is
invalidated (GPU rendering is not allowed in the background). On foreground
nothing re-attaches or recreates it, so the external display keeps showing
the stale frame. Reconnecting the cable works only because iOS recreates the
external scene/window, which re-runs the attach path.

### Fix
In `playerControllerApplicationBecameActive`, when the app becomes active
again while playing on an external screen (and not casting to a renderer,
with an external window present), toggle the video output off and back on
(`videoOutputView = nil` then the view again). This removes the output view
from the external window and re-inserts it, forcing the vout surface to be
recreated.

The new branch is guarded so it is only entered for a wired external display:
`isPlayingOnExternalScreen()` together with `renderer == nil` excludes
Chromecast, and `externalWindow != nil` excludes the local-screen case, which
keeps following the existing code path unchanged.

### Testing
Verified on a physical device with a wired external monitor: play video →
background → return to foreground → the picture resumes in sync with audio
without reconnecting the display.